### PR TITLE
Implement ReferenceParser for CTS URN resolution via citeStructure

### DIFF
--- a/src/python/mvp/reference_parser.py
+++ b/src/python/mvp/reference_parser.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Optional
+
+from lxml import etree
+
+from mvp.tei_document import TEIDocument, NS, XML_ID
+
+
+class ConfigurationError(Exception):
+    """Raised when no usable citeStructure can be found or selected."""
+
+
+class CitationError(Exception):
+    """Raised when a URN is syntactically invalid or resolves to nothing."""
+
+
+class ReferenceParser:
+    def __init__(
+        self,
+        tei_doc: TEIDocument,
+        refsDecl_id: str | None = None,
+    ) -> None:
+        root = tei_doc.root
+
+        body = root.find(".//tei:body", NS)
+        if body is None:
+            raise ConfigurationError("No <body> element found in document")
+        self._body = body
+
+        self._base_urn = body.get("n", "")
+        if not self._base_urn:
+            raise ConfigurationError(
+                "No base URN found in <body @n>. "
+                "Ensure the document has been normalized with @n on <body>."
+            )
+
+        refs_decls = root.findall(".//tei:refsDecl", NS)
+
+        if refsDecl_id is not None:
+            target = next(
+                (rd for rd in refs_decls if rd.get(XML_ID) == refsDecl_id),
+                None,
+            )
+            if target is None:
+                raise ConfigurationError(
+                    f"No <refsDecl> with xml:id={refsDecl_id!r}"
+                )
+            cs = target.find("tei:citeStructure", NS)
+            if cs is None:
+                raise ConfigurationError(
+                    f"<refsDecl xml:id={refsDecl_id!r}> contains no <citeStructure>"
+                )
+            self._root_cs = cs
+        else:
+            cs_decls = [
+                (rd, rd.find("tei:citeStructure", NS))
+                for rd in refs_decls
+            ]
+            cs_decls = [(rd, cs) for rd, cs in cs_decls if cs is not None]
+
+            if not cs_decls:
+                raise ConfigurationError(
+                    "No <refsDecl> with a <citeStructure> found. "
+                    "Run conversion tooling to add <citeStructure> declarations first."
+                )
+
+            defaults = [
+                (rd, cs) for rd, cs in cs_decls if rd.get("default") == "true"
+            ]
+            if defaults:
+                self._root_cs = defaults[0][1]
+            elif len(cs_decls) == 1:
+                self._root_cs = cs_decls[0][1]
+            else:
+                raise ConfigurationError(
+                    "Multiple <refsDecl> elements contain <citeStructure>; "
+                    "supply refsDecl_id to select one explicitly."
+                )
+
+    def resolve(self, urn: str) -> etree._Element:
+        """Return the element identified by the full CTS URN.
+
+        Partial citations (e.g. book only when book/chapter/section is the full
+        hierarchy) are valid and resolve to the element at that level.
+        Raises CitationError if the URN is malformed or matches nothing.
+        """
+        prefix = self._base_urn + ":"
+        if not urn.startswith(prefix):
+            raise CitationError(
+                f"URN base does not match document. "
+                f"Expected prefix {prefix!r}, got {urn!r}"
+            )
+        passage = urn[len(prefix):]
+        if not passage:
+            raise CitationError(f"URN has no passage component: {urn!r}")
+
+        children = list(self._root_cs.findall("tei:citeStructure", NS))
+        if not children:
+            raise CitationError("Root <citeStructure> has no children to resolve against")
+
+        return self._resolve_passage(passage, children, self._body)
+
+    def _resolve_passage(
+        self,
+        passage: str,
+        cs_list: list[etree._Element],
+        context: etree._Element,
+    ) -> etree._Element:
+        last_error: CitationError = CitationError(f"Cannot resolve passage {passage!r}")
+        for cs in cs_list:
+            try:
+                return self._resolve_with_cs(passage, cs, context)
+            except CitationError as exc:
+                last_error = exc
+        raise last_error
+
+    def _resolve_with_cs(
+        self,
+        passage: str,
+        cs: etree._Element,
+        context: etree._Element,
+    ) -> etree._Element:
+        children = list(cs.findall("tei:citeStructure", NS))
+
+        if children:
+            next_delim = children[0].get("delim", ".")
+            token, sep, rest = passage.partition(next_delim)
+            if not sep:
+                # Delimiter not found — partial citation stopping at this level.
+                token = passage
+                rest = ""
+        else:
+            token = passage
+            rest = ""
+
+        match_expr = cs.get("match", "")
+        use_attr = cs.get("use", "@n")
+        candidates: list[etree._Element] = context.xpath(match_expr, namespaces=NS)
+
+        matched: Optional[etree._Element] = None
+        if use_attr.startswith("@"):
+            attr_name = use_attr[1:]
+            for cand in candidates:
+                if cand.get(attr_name) == token:
+                    matched = cand
+                    break
+
+        if matched is None:
+            raise CitationError(
+                f"No element with {use_attr}={token!r} "
+                f"via match={match_expr!r}"
+            )
+
+        if rest:
+            if not children:
+                raise CitationError(
+                    f"Passage has trailing component {rest!r} "
+                    f"but citation hierarchy is exhausted"
+                )
+            return self._resolve_passage(rest, children, matched)
+        return matched
+
+    def generate(self, element: etree._Element) -> str:
+        """Return the full CTS URN for a citable element.
+
+        Raises CitationError if the element is not reachable from any
+        level of the active citeStructure.
+        """
+        path = self._find_path_to(element, self._root_cs, self._body)
+        if path is None:
+            raise CitationError(
+                f"Element <{etree.QName(element.tag).localname}> "
+                f"is not reachable via the active citeStructure"
+            )
+        parts: list[str] = []
+        for cs, elem in path:
+            delim = cs.get("delim", ":")
+            use_attr = cs.get("use", "@n")
+            val = elem.get(use_attr[1:], "") if use_attr.startswith("@") else ""
+            parts.append(delim + val)
+        return self._base_urn + "".join(parts)
+
+    def _find_path_to(
+        self,
+        target: etree._Element,
+        parent_cs: etree._Element,
+        context: etree._Element,
+    ) -> Optional[list[tuple[etree._Element, etree._Element]]]:
+        for cs in parent_cs.findall("tei:citeStructure", NS):
+            match_expr = cs.get("match", "")
+            candidates: list[etree._Element] = context.xpath(match_expr, namespaces=NS)
+
+            if any(cand is target for cand in candidates):
+                return [(cs, target)]
+
+            for cand in candidates:
+                result = self._find_path_to(target, cs, cand)
+                if result is not None:
+                    return [(cs, cand)] + result
+
+        return None
+
+    def citations(self, depth: int = -1) -> Iterator[str]:
+        """Yield every resolvable CTS URN in document order.
+
+        depth=-1 (default): yield citations at every level of the hierarchy.
+        depth=0: yield only root-level citations.
+        depth=N (positive): yield citations up to and including level N (0-based).
+        """
+        children = list(self._root_cs.findall("tei:citeStructure", NS))
+        yield from self._citations_recursive("", children, self._body, 0, depth)
+
+    def _citations_recursive(
+        self,
+        suffix: str,
+        cs_list: list[etree._Element],
+        context: etree._Element,
+        current_depth: int,
+        max_depth: int,
+    ) -> Iterator[str]:
+        for cs in cs_list:
+            match_expr = cs.get("match", "")
+            use_attr = cs.get("use", "@n")
+            delim = cs.get("delim", ":")
+            children = list(cs.findall("tei:citeStructure", NS))
+            candidates: list[etree._Element] = context.xpath(match_expr, namespaces=NS)
+
+            for cand in candidates:
+                val = cand.get(use_attr[1:], "") if use_attr.startswith("@") else ""
+                new_suffix = suffix + delim + val
+
+                if max_depth == -1 or current_depth <= max_depth:
+                    yield self._base_urn + new_suffix
+
+                if (max_depth == -1 or current_depth < max_depth) and children:
+                    yield from self._citations_recursive(
+                        new_suffix, children, cand, current_depth + 1, max_depth
+                    )

--- a/tests/test_reference_parser.py
+++ b/tests/test_reference_parser.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from mvp.tei_document import TEIDocument
+from mvp.reference_parser import CitationError, ConfigurationError, ReferenceParser
+
+# ---------------------------------------------------------------------------
+# Helpers and fixture XML
+# ---------------------------------------------------------------------------
+
+TEI_NS = "http://www.tei-c.org/ns/1.0"
+
+
+def write_xml(tmp_path: Path, xml: str) -> Path:
+    p = tmp_path / "test.xml"
+    p.write_text(textwrap.dedent(xml), encoding="utf-8")
+    return p
+
+
+APOLOGY_BASE = "urn:cts:greekLit:tlg0059.tlg002.perseus-grc2"
+
+APOLOGY_XML = f"""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <TEI xmlns="http://www.tei-c.org/ns/1.0">
+      <teiHeader>
+        <encodingDesc>
+          <refsDecl xml:id="cite_by_section" default="true">
+            <citeStructure match="/tei:TEI/tei:text/tei:body" use="@n">
+              <citeStructure unit="section" delim=":" match="tei:div[@type='textpart']" use="@n"/>
+            </citeStructure>
+          </refsDecl>
+        </encodingDesc>
+      </teiHeader>
+      <text>
+        <body n="{APOLOGY_BASE}">
+          <div type="textpart" subtype="section" n="17"><p>ὅτι μέν...</p></div>
+          <div type="textpart" subtype="section" n="18"><p>τοῦτο...</p></div>
+          <div type="textpart" subtype="section" n="19"><p>ἴσως...</p></div>
+        </body>
+      </text>
+    </TEI>
+"""
+
+THUCYDIDES_BASE = "urn:cts:greekLit:tlg0003.tlg001.perseus-grc2"
+
+THUCYDIDES_XML = f"""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <TEI xmlns="http://www.tei-c.org/ns/1.0">
+      <teiHeader>
+        <encodingDesc>
+          <refsDecl xml:id="cite_by_section" default="true">
+            <citeStructure match="/tei:TEI/tei:text/tei:body" use="@n">
+              <citeStructure unit="book" delim=":" match="tei:div[@subtype='book']" use="@n">
+                <citeStructure unit="chapter" delim="." match="tei:div[@subtype='chapter']" use="@n">
+                  <citeStructure unit="section" delim="." match="tei:div[@subtype='section']" use="@n"/>
+                </citeStructure>
+              </citeStructure>
+            </citeStructure>
+          </refsDecl>
+        </encodingDesc>
+      </teiHeader>
+      <text>
+        <body n="{THUCYDIDES_BASE}">
+          <div type="textpart" subtype="book" n="1">
+            <div type="textpart" subtype="chapter" n="1">
+              <div type="textpart" subtype="section" n="1"><p>Θουκυδίδης...</p></div>
+              <div type="textpart" subtype="section" n="2"><p>text</p></div>
+              <div type="textpart" subtype="section" n="3"><p>text</p></div>
+            </div>
+            <div type="textpart" subtype="chapter" n="2">
+              <div type="textpart" subtype="section" n="1"><p>text</p></div>
+              <div type="textpart" subtype="section" n="2"><p>text</p></div>
+            </div>
+          </div>
+          <div type="textpart" subtype="book" n="2">
+            <div type="textpart" subtype="chapter" n="1">
+              <div type="textpart" subtype="section" n="1"><p>text</p></div>
+            </div>
+          </div>
+        </body>
+      </text>
+    </TEI>
+"""
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def apology_doc(tmp_path):
+    return TEIDocument(write_xml(tmp_path, APOLOGY_XML))
+
+
+@pytest.fixture
+def apology_parser(apology_doc):
+    return ReferenceParser(apology_doc)
+
+
+@pytest.fixture
+def thucydides_doc(tmp_path):
+    return TEIDocument(write_xml(tmp_path, THUCYDIDES_XML))
+
+
+@pytest.fixture
+def thucydides_parser(thucydides_doc):
+    return ReferenceParser(thucydides_doc)
+
+
+# ---------------------------------------------------------------------------
+# Apology — constructor
+# ---------------------------------------------------------------------------
+
+
+class TestApologyConstructor:
+
+    def test_no_default_single_cs_succeeds(self, tmp_path):
+        xml = f"""\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <TEI xmlns="http://www.tei-c.org/ns/1.0">
+              <teiHeader>
+                <encodingDesc>
+                  <refsDecl xml:id="cite_by_section">
+                    <citeStructure match="/tei:TEI/tei:text/tei:body" use="@n">
+                      <citeStructure unit="section" delim=":" match="tei:div[@type='textpart']" use="@n"/>
+                    </citeStructure>
+                  </refsDecl>
+                </encodingDesc>
+              </teiHeader>
+              <text>
+                <body n="{APOLOGY_BASE}">
+                  <div type="textpart" n="1"><p>text</p></div>
+                </body>
+              </text>
+            </TEI>
+        """
+        doc = TEIDocument(write_xml(tmp_path, xml))
+        assert ReferenceParser(doc) is not None
+
+    def test_no_cite_structure_raises(self, tmp_path):
+        xml = f"""\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <TEI xmlns="http://www.tei-c.org/ns/1.0">
+              <teiHeader>
+                <encodingDesc>
+                  <refsDecl n="CTS">
+                    <cRefPattern n="section" matchPattern="(\\w+)"
+                                 replacementPattern="#xpath(...)">
+                      <p>section</p>
+                    </cRefPattern>
+                  </refsDecl>
+                </encodingDesc>
+              </teiHeader>
+              <text>
+                <body n="{APOLOGY_BASE}">
+                  <div type="textpart" n="1"><p>text</p></div>
+                </body>
+              </text>
+            </TEI>
+        """
+        doc = TEIDocument(write_xml(tmp_path, xml))
+        with pytest.raises(ConfigurationError):
+            ReferenceParser(doc)
+
+    def test_nonexistent_refsDecl_id_raises(self, apology_doc):
+        with pytest.raises(ConfigurationError):
+            ReferenceParser(apology_doc, refsDecl_id="no_such_id")
+
+    def test_explicit_refsDecl_id_selects_correct_decl(self, apology_doc):
+        assert ReferenceParser(apology_doc, refsDecl_id="cite_by_section") is not None
+
+
+# ---------------------------------------------------------------------------
+# Apology — resolve
+# ---------------------------------------------------------------------------
+
+
+class TestApologyResolve:
+
+    def test_resolve_known_section(self, apology_parser):
+        elem = apology_parser.resolve(f"{APOLOGY_BASE}:17")
+        assert elem.get("n") == "17"
+        assert elem.get("type") == "textpart"
+
+    def test_resolve_wrong_base_raises(self, apology_parser):
+        with pytest.raises(CitationError):
+            apology_parser.resolve("urn:cts:greekLit:tlg9999.tlg001.foo:17")
+
+    def test_resolve_nonexistent_section_raises(self, apology_parser):
+        with pytest.raises(CitationError):
+            apology_parser.resolve(f"{APOLOGY_BASE}:99")
+
+
+# ---------------------------------------------------------------------------
+# Apology — generate
+# ---------------------------------------------------------------------------
+
+
+class TestApologyGenerate:
+
+    def test_generate_known_section(self, apology_doc, apology_parser):
+        body = apology_doc.root.find(f".//{{{TEI_NS}}}body")
+        div_17 = next(
+            d for d in body.findall(f"{{{TEI_NS}}}div") if d.get("n") == "17"
+        )
+        assert apology_parser.generate(div_17) == f"{APOLOGY_BASE}:17"
+
+    def test_generate_unreachable_element_raises(self, apology_doc, apology_parser):
+        # <p> elements are not citable at any citeStructure level.
+        p = apology_doc.root.find(f".//{{{TEI_NS}}}p")
+        with pytest.raises(CitationError):
+            apology_parser.generate(p)
+
+
+# ---------------------------------------------------------------------------
+# Apology — citations
+# ---------------------------------------------------------------------------
+
+
+class TestApologyCitations:
+
+    def test_citations_all_levels_count(self, apology_parser):
+        assert len(list(apology_parser.citations(depth=-1))) == 3
+
+    def test_citations_depth_zero_same_as_all(self, apology_parser):
+        # Single-level hierarchy: depth=0 (root) is also the leaf level.
+        assert len(list(apology_parser.citations(depth=0))) == 3
+
+    def test_citations_document_order(self, apology_parser):
+        assert list(apology_parser.citations()) == [
+            f"{APOLOGY_BASE}:17",
+            f"{APOLOGY_BASE}:18",
+            f"{APOLOGY_BASE}:19",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Thucydides — resolve
+# ---------------------------------------------------------------------------
+
+
+class TestThucydidesResolve:
+
+    def test_resolve_full_three_level(self, thucydides_parser):
+        # Book 1, chapter 1 has sections 1-3; use 1.1.3 as the full citation.
+        elem = thucydides_parser.resolve(f"{THUCYDIDES_BASE}:1.1.3")
+        assert elem.get("subtype") == "section"
+        assert elem.get("n") == "3"
+        chapter = elem.getparent()
+        assert chapter.get("subtype") == "chapter"
+        assert chapter.get("n") == "1"
+        book = chapter.getparent()
+        assert book.get("subtype") == "book"
+        assert book.get("n") == "1"
+
+    def test_resolve_partial_book(self, thucydides_parser):
+        elem = thucydides_parser.resolve(f"{THUCYDIDES_BASE}:1")
+        assert elem.get("subtype") == "book"
+        assert elem.get("n") == "1"
+
+    def test_resolve_partial_chapter(self, thucydides_parser):
+        elem = thucydides_parser.resolve(f"{THUCYDIDES_BASE}:1.2")
+        assert elem.get("subtype") == "chapter"
+        assert elem.get("n") == "2"
+
+
+# ---------------------------------------------------------------------------
+# Thucydides — generate
+# ---------------------------------------------------------------------------
+
+
+class TestThucydidesGenerate:
+
+    def _get(self, doc, **attrs):
+        """Find a div by keyword attrs (subtype, n)."""
+        root = doc.root
+        for div in root.iter(f"{{{TEI_NS}}}div"):
+            if all(div.get(k) == v for k, v in attrs.items()):
+                return div
+        raise KeyError(attrs)
+
+    def test_generate_section_full_urn(self, thucydides_doc, thucydides_parser):
+        # Section 3 of chapter 1 of book 1 (1.1.3 exists in the fixture).
+        book1 = self._get(thucydides_doc, subtype="book", n="1")
+        ch1 = next(
+            d for d in book1 if d.get("subtype") == "chapter" and d.get("n") == "1"
+        )
+        sec3 = next(
+            d for d in ch1 if d.get("subtype") == "section" and d.get("n") == "3"
+        )
+        assert thucydides_parser.generate(sec3) == f"{THUCYDIDES_BASE}:1.1.3"
+
+    def test_generate_book_partial_urn(self, thucydides_doc, thucydides_parser):
+        book1 = self._get(thucydides_doc, subtype="book", n="1")
+        assert thucydides_parser.generate(book1) == f"{THUCYDIDES_BASE}:1"
+
+
+# ---------------------------------------------------------------------------
+# Thucydides — citations
+# ---------------------------------------------------------------------------
+
+
+class TestThucydidesCitations:
+
+    def test_citations_depth_zero_books_only(self, thucydides_parser):
+        urns = list(thucydides_parser.citations(depth=0))
+        assert urns == [
+            f"{THUCYDIDES_BASE}:1",
+            f"{THUCYDIDES_BASE}:2",
+        ]
+
+    def test_citations_depth_one_books_and_chapters(self, thucydides_parser):
+        urns = list(thucydides_parser.citations(depth=1))
+        # 2 books + 3 chapters (book1→2 chapters, book2→1 chapter)
+        assert len(urns) == 5
+        assert f"{THUCYDIDES_BASE}:1" in urns
+        assert f"{THUCYDIDES_BASE}:1.1" in urns
+        assert f"{THUCYDIDES_BASE}:1.2" in urns
+        assert f"{THUCYDIDES_BASE}:2" in urns
+        assert f"{THUCYDIDES_BASE}:2.1" in urns
+
+    def test_citations_all_levels_count(self, thucydides_parser):
+        # 2 books + 3 chapters + 6 sections = 11
+        assert len(list(thucydides_parser.citations(depth=-1))) == 11
+
+    def test_citations_document_order(self, thucydides_parser):
+        urns = list(thucydides_parser.citations(depth=-1))
+        assert urns[0] == f"{THUCYDIDES_BASE}:1"
+        assert urns[1] == f"{THUCYDIDES_BASE}:1.1"
+        assert urns[2] == f"{THUCYDIDES_BASE}:1.1.1"
+        assert urns[-1] == f"{THUCYDIDES_BASE}:2.1.1"


### PR DESCRIPTION
## Summary

- Adds `mvp/reference_parser.py` with `ReferenceParser`, `ConfigurationError`, and `CitationError`
- Resolves full and partial CTS URNs to TEI elements, generates URNs from elements, and yields all citations in document order — all driven by `<citeStructure>` declarations in the `<teiHeader>`
- 21 tests in `tests/test_reference_parser.py` covering single-level (Apology) and three-level (Thucydides) fixtures

## Design notes

`ReferenceParser.__init__` selects a `<refsDecl>` containing a `<citeStructure>`, preferring `default="true"`, falling back to the sole candidate, and raising `ConfigurationError` if neither condition is met (including the legacy `<cRefPattern>`-only case). The `refsDecl_id` parameter allows explicit selection when multiple candidates exist.

`resolve()` walks the `<citeStructure>` tree recursively, splitting the passage string on each child level's `@delim` via `str.partition`; partial citations stop at the last matched level. `generate()` does a DFS through the tree using element identity (`is`) to locate the target, then assembles the passage by concatenating `@delim` + `@use` values. `citations(depth)` yields all resolvable URNs in document order with depth-controlled scope.

## Test plan

- [ ] `pdm run test tests/test_reference_parser.py -v` — all 21 pass
- [ ] `pdm run test -m 'not slow'` — no regressions (1 pre-existing strategy failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)