### PR TITLE
Fix .gitignore to match wiki symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,4 +238,4 @@ src/morph-server/*.morph.xml
 data/
 
 # The wiki is a submodule; don't track
-wiki/
+wiki


### PR DESCRIPTION
## Summary

- `wiki/` (trailing slash) only matches directories in git; `wiki` is a symlink, which git treats as a regular file, so the pattern never fired
- Removing the trailing slash makes the pattern match both files and directories

## Test plan

- [ ] `git status` no longer shows `wiki` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)