### PR TITLE
Restore three-column layout CSS

### DIFF
--- a/src/xslt/html/chunker_core.xsl
+++ b/src/xslt/html/chunker_core.xsl
@@ -23,28 +23,7 @@
   version="3.0"
   exclude-result-prefixes="tei xs local">
 
-  <!-- ============================================================
-       Shared page CSS (used by generate_chunks.xsl and generate_div_chunks.xsl)
-       ============================================================ -->
-
-  <xsl:variable name="page-css" as="xs:string">body         { font-family: serif; max-width: 48em; margin: 0 auto; padding: 1em 2em }
-.site-header { border-bottom: 1px solid #ccc; margin-bottom: 1.5em;
-               padding-bottom: .5em; font-size: .9em; color: #555 }
-.site-header a { text-decoration: none; font-weight: bold; color: inherit }
-.chunk-nav   { display: flex; justify-content: space-between; font-size: .9em;
-               margin-bottom: 1.5em }
-.chunk-nav a { margin-right: 1em }
-h1           { font-size: 1em; color: #555; margin-bottom: .25em }
-.speech      { margin: 1em 0 }
-.speaker     { font-weight: bold; display: block; margin-bottom: .25em }
-.line        { margin: .1em 0; padding-left: 2em }
-.gap         { color: #888; font-style: italic }
-.note        { border-bottom: 1px dotted #888 }
-.toc         { padding-left: 1.5em; line-height: 1.8 }
-.site-footer { border-top: 1px solid #eee; margin-top: 2em; padding-top: .5em;
-               font-size: .8em; color: #888; text-align: center }
-a.word       { color: inherit; text-decoration: none; border-bottom: 1px dotted #aaa }
-a.word:hover { border-bottom-style: solid }</xsl:variable>
+  <xsl:import href="variables.xsl"/>
 
   <!-- ============================================================
        Helper functions

--- a/src/xslt/html/driver.xsl
+++ b/src/xslt/html/driver.xsl
@@ -9,8 +9,8 @@
     xmlns:tei="http://www.tei-c.org/ns/1.0"
     exclude-result-prefixes="xs tei"
     version="4.0">
-    <xsl:import href="core.xsl"/>
-    <xsl:import href="textstructure.xsl"/>
+    <xsl:import href="tei/core.xsl"/>
+    <xsl:import href="tei/textstructure.xsl"/>
     
     <xsl:output method="html" doctype-system="about:legacy-compat" />
     

--- a/src/xslt/html/variables.xsl
+++ b/src/xslt/html/variables.xsl
@@ -3,36 +3,230 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:tei="http://www.tei-c.org/ns/1.0"
     exclude-result-prefixes="xs tei"
-    version="4.0">
-    
+    version="3.0">
+
     <xsl:variable name="page-css" as="xs:string">
-        :root {
-        --color-bg-primary:     #ffffff;
-        --color-bg-secondary:   #f7f7f5;
-        --color-text-primary:   #1a1a1a;
-        --color-text-secondary: #555555;
-        --color-text-tertiary:  #999999;
-        --color-border-primary:   #cccccc;
-        --color-border-secondary: #dddddd;
-        --color-border-tertiary:  #e8e8e6;
-        --font-sans:  system-ui, -apple-system, sans-serif;
-        --font-serif: Georgia, 'Times New Roman', serif;
-        --font-mono:  'Courier New', Courier, monospace;
-        --radius-sm: 3px;
-        --radius-md: 4px;
-        }
-        p { line-height: 1.7; margin-bottom: .75em; font-family: var(--font-serif); font-size: 14px; color: var(--color-text-primary); position: relative; }
-        
-        .tei-del {
-        text-decoration: line-through;
-        color: red;
-        }
-        
-        .tei-add {
-        text-decoration: none;
-        color: blue;
-        }
-        
+*, *::before, *::after { box-sizing: border-box; }
+
+:root {
+  --color-bg-primary:       #ffffff;
+  --color-bg-secondary:     #f7f7f5;
+  --color-text-primary:     #1a1a1a;
+  --color-text-secondary:   #555555;
+  --color-text-tertiary:    #999999;
+  --color-border-primary:   #cccccc;
+  --color-border-secondary: #dddddd;
+  --color-border-tertiary:  #e8e8e6;
+  --font-sans:  system-ui, -apple-system, sans-serif;
+  --font-serif: Georgia, 'Times New Roman', serif;
+  --font-mono:  'Courier New', Courier, monospace;
+  --radius-sm: 3px;
+  --radius-md: 4px;
+}
+
+/* ── Shell layout ── */
+.perseus-shell {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
+}
+.main-area {
+  display: grid;
+  grid-template-columns: 220px 1fr 220px;
+  align-items: start;
+}
+
+/* ── Sidebars ── */
+.sidebar {
+  background: var(--color-bg-secondary);
+  border-right: 1px solid var(--color-border-tertiary);
+  padding: 1em;
+  font-size: .85em;
+  font-family: var(--font-sans);
+  min-height: 100%;
+}
+.sidebar.right {
+  border-right: none;
+  border-left: 1px solid var(--color-border-tertiary);
+}
+
+/* ── Site header ── */
+.site-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: .5em 1em;
+  border-bottom: 1px solid var(--color-border-primary);
+  font-family: var(--font-sans);
+  font-size: .9em;
+  color: var(--color-text-secondary);
+}
+.header-logo { font-weight: bold; letter-spacing: .05em; }
+.header-logo span { font-weight: normal; }
+.header-nav a { margin-left: 1em; text-decoration: none; color: inherit; }
+.header-nav a:hover { text-decoration: underline; }
+
+/* ── Site footer ── */
+.site-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: .5em 1em;
+  border-top: 1px solid var(--color-border-tertiary);
+  font-family: var(--font-sans);
+  font-size: .8em;
+  color: var(--color-text-tertiary);
+}
+.footer-links a { margin-left: .75em; text-decoration: none; color: inherit; }
+.footer-links a:hover { text-decoration: underline; }
+
+/* ── Center column ── */
+.center-col { padding: 1em 2em; }
+
+/* ── Passage header / nav ── */
+.passage-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 1.5em;
+  padding-bottom: .5em;
+  border-bottom: 1px solid var(--color-border-secondary);
+  font-family: var(--font-sans);
+  font-size: .9em;
+  color: var(--color-text-secondary);
+}
+.passage-breadcrumb strong { color: var(--color-text-primary); }
+.passage-nav { display: flex; gap: .5em; }
+.nav-btn {
+  text-decoration: none;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--radius-sm);
+  padding: .1em .5em;
+  font-size: .85em;
+}
+.nav-btn:hover { background: var(--color-bg-secondary); }
+
+/* ── Text body: padding reserves room for absolute-positioned sidenotes ── */
+.text-body { padding-right: 230px; position: relative; }
+
+/* ── Passage footer / display options ── */
+.passage-footer {
+  margin-top: 1.5em;
+  padding-top: .5em;
+  border-top: 1px solid var(--color-border-secondary);
+  font-family: var(--font-sans);
+  font-size: .85em;
+  color: var(--color-text-secondary);
+}
+.display-opts { display: flex; align-items: center; gap: .5em; }
+
+/* ── CSS checkbox hack: toggle-input controls .line-n visibility ── */
+.toggle-input { display: none; }
+.toggle-input:not(:checked) ~ .text-body .line-n { display: none; }
+
+/* ── Verse lines ── */
+p.line {
+  display: flex;
+  align-items: baseline;
+  margin: .1em 0;
+  font-family: var(--font-serif);
+  font-size: 14px;
+  color: var(--color-text-primary);
+  position: relative;
+}
+.line-n {
+  min-width: 2.5em;
+  color: var(--color-text-tertiary);
+  font-size: .8em;
+  text-align: right;
+  padding-right: .75em;
+  flex-shrink: 0;
+}
+.line-text { flex: 1; }
+
+/* ── Prose paragraphs ── */
+p {
+  line-height: 1.7;
+  margin-bottom: .75em;
+  font-family: var(--font-serif);
+  font-size: 14px;
+  color: var(--color-text-primary);
+  position: relative;
+}
+
+/* ── Inline notes rendered as sidenotes ── */
+.note {
+  position: absolute;
+  right: -220px;
+  width: 210px;
+  font-size: .8em;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+  border-left: 2px solid var(--color-border-secondary);
+  padding-left: .5em;
+}
+
+/* ── TOC list ── */
+.toc-list { list-style: none; padding: 0; margin: 0; line-height: 1.8; }
+.toc-list a {
+  text-decoration: none;
+  color: var(--color-text-secondary);
+  display: flex;
+  align-items: center;
+  gap: .4em;
+}
+.toc-list a:hover { color: var(--color-text-primary); }
+.toc-list li.current > a { font-weight: bold; color: var(--color-text-primary); }
+.toc-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--color-border-primary);
+  flex-shrink: 0;
+}
+.toc-list li.current .toc-dot { background: var(--color-text-secondary); }
+
+/* ── Details / summary collapsible panels ── */
+details { margin-bottom: .75em; }
+summary {
+  font-weight: bold;
+  cursor: pointer;
+  font-size: .9em;
+  padding: .25em 0;
+  color: var(--color-text-secondary);
+  list-style: none;
+}
+summary::-webkit-details-marker { display: none; }
+summary::before { content: '\25B6  '; font-size: .7em; }
+details[open] > summary::before { content: '\25BC  '; }
+.panel-body { padding: .5em 0; }
+
+/* ── Work-info metadata rows ── */
+.meta-row { display: flex; gap: .5em; font-size: .85em; margin-bottom: .35em; }
+.meta-label { color: var(--color-text-tertiary); min-width: 5em; }
+.meta-value { color: var(--color-text-primary); }
+
+/* ── Sidebar placeholder messages ── */
+.placeholder-msg {
+  color: var(--color-text-tertiary);
+  font-style: italic;
+  font-size: .85em;
+  margin: 0;
+  line-height: 1.4;
+}
+
+/* ── Speech blocks ── */
+.speech { margin: 1em 0; }
+.speaker { font-weight: bold; display: block; margin-bottom: .25em; }
+
+/* ── Editorial marks ── */
+.gap { color: #888; font-style: italic; }
+.tei-del { text-decoration: line-through; color: red; }
+.tei-add { text-decoration: none; color: blue; }
+
+/* ── Word links (morphological server) ── */
+a.word { color: inherit; text-decoration: none; border-bottom: 1px dotted #aaa; }
+a.word:hover { border-bottom-style: solid; }
     </xsl:variable>
-    
+
 </xsl:stylesheet>

--- a/tests/data/tlg0003.tlg001.perseus-grc2.xml
+++ b/tests/data/tlg0003.tlg001.perseus-grc2.xml
@@ -53,28 +53,16 @@
       </fileDesc>
     
       <encodingDesc>
-         <refsDecl n="CTS">
-            <cRefPattern n="section"
-                         matchPattern="(\w+).(\w+).(\w+)"
-                         replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:div[@n='$2']/tei:div[@n='$3'])">
-                <p>This pointer pattern extracts book and chapter and section</p>
-            </cRefPattern>
-            <cRefPattern n="chapter"
-                         matchPattern="(\w+).(\w+)"
-                         replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:div[@n='$2'])">
-                <p>This pointer pattern extracts book and chapter</p>
-            </cRefPattern>
-            <cRefPattern n="book"
-                         matchPattern="(\w+)"
-                         replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
-                <p>This pointer pattern extracts book</p>
-            </cRefPattern>
-        </refsDecl>
-         <refsDecl>
-            <refState unit="book" delim="."/>
-            <refState unit="chapter" delim="."/>
-            <refState unit="section"/>
-         </refsDecl>
+        <refsDecl xml:id="cite_by_section" default="true">
+            <citeStructure match="/tei:TEI/tei:text/tei:body" use="@n">
+              <citeStructure unit="book" delim=":" match="tei:div[@subtype='book']" use="@n">
+                <citeStructure unit="chapter" delim="." match="tei:div[@subtype='chapter']" use="@n">
+                  <citeStructure unit="section" delim="." match="tei:div[@subtype='section']" use="@n"/>
+                </citeStructure>
+              </citeStructure>
+            </citeStructure>
+          </refsDecl>
+
       </encodingDesc>
     
       <profileDesc>
@@ -91,8 +79,7 @@
   </teiHeader>
   
   <text>
-      <body>
-         <div type="edition" n="urn:cts:greekLit:tlg0003.tlg001.perseus-grc2" xml:lang="grc">
+      <body n="urn:cts:greekLit:tlg0003.tlg001.perseus-grc2">
         <div type="textpart" subtype="book" xml:base="urn:cts:greekLit:tlg0003.tlg001.perseus-grc2" n="1"> 
         <div type="textpart" subtype="chapter" xml:base="urn:cts:greekLit:tlg0003.tlg001.perseus-grc2:1" n="1">
                   <div type="textpart" subtype="section" xml:base="urn:cts:greekLit:tlg0003.tlg001.perseus-grc2:1.1" n="1">
@@ -22957,7 +22944,6 @@
                   </div>
                </div>
             </div>
-         </div>   
       </body>
   </text>
 </TEI>

--- a/tests/data/tlg0086.tlg034.perseus-grc2.xml
+++ b/tests/data/tlg0086.tlg034.perseus-grc2.xml
@@ -84,7 +84,7 @@
  </teiHeader>
   
 <text>
-<body>
+<body n="urn:cts:greekLit:tlg0086.tlg034.perseus-grc2">
 <div type="edition" xml:lang="grc" n="urn:cts:greekLit:tlg0086.tlg034.perseus-grc2">
   <div type="textpart" subtype="chapter" xml:base="urn:cts:greekLit:tlg0086.tlg034.perseus-grc2" n="1">   
     <div type="textpart" subtype="subchapter" xml:base="urn:cts:greekLit:tlg0086.tlg034.perseus-grc2:1" n="1">


### PR DESCRIPTION
## Summary

- Expands `variables.xsl` `$page-css` to include the full three-column reader layout: shell grid, sidebars, passage header/nav, verse lines, sidenotes, TOC, `<details>`/`<summary>` panels, and CSS checkbox line-number toggle
- Has `chunker_core.xsl` import `variables.xsl` instead of defining its own minimal `$page-css`, making `variables.xsl` the single source of CSS truth for both chunker stylesheets
- Fixes `driver.xsl` import paths (`core.xsl` / `textstructure.xsl` → `tei/core.xsl` / `tei/textstructure.xsl`)
- Also commits test fixture updates (citeStructure in tlg0003, `body @n` in tlg0086) that were prepared for the ReferenceParser work but missed in the squash merge of PR #49

The HTML shell in `generate_chunks.xsl` and `generate_div_chunks.xsl` was already complete; only the missing CSS prevented the three-column layout from rendering.

## Test plan

- [ ] All non-slow Python tests pass (`pdm run test -m 'not slow'` — 298 pass, 1 pre-existing failure unrelated to this change)
- [ ] Saxon smoke test: `generate_chunks.xsl` on `phi1017.phi007.perseus-lat2.xml` produces HTML with `grid-template-columns: 220px` in embedded `<style>` and all layout classes (`.perseus-shell`, `.main-area`, `.sidebar`, `.center-col`, etc.) present
- [ ] Open generated page in browser and confirm three-column layout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)