### PR TITLE
Address ReferenceParser review feedback

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,34 +1,186 @@
-# Perseus6 — Claude Code context
-
-## What this project is
-
-Perseus6 is a compiler-based reading environment for the Perseus Digital
-Library, replacing Perseus 4 (the Hopper). It takes TEI-encoded XML texts and
-produces static HTML pages, catalogs, citation tables, vocabulary aids, and
-passage alignments — all navigable by web browser without JavaScript or a
-back-end database.
-
-## Design philosophy
-
-**Minimal computing.** Perseus6 is data-forward: it generates artifacts that
-others can serve or build on, rather than running services itself. Prefer
-simplicity. Avoid external dependencies. Do not introduce JavaScript
-requirements into the HTML output.
-
-## Languages and tooling
-
-- **Python 3.14.3** — primary implementation language
-- **XSLT 3.0 / Saxon** — TEI-to-HTML transformation pipeline
-- See `.claude/guidelines/python.md` for Python conventions used in this repo
-
-## Before starting any coding task
-
-Read all files in `.claude/guidelines/`.
+# Perseus 6 and Minimum Viable Perseus — Claude Code context
 
 
 
-## Further reading
+## Project Scope
 
-The project wiki is available at `wiki/` (git submodule).  It contains
-standards, workflows, best practices, and design documents including the
-chunking and CTS URN architecture.
+### What Perseus 6 and Minimum Viable Perseus Are
+
+Perseus 6 will be the successor to [Perseus 4, currently in
+production](https://www.perseus.tufts.edu/hopper/). It will
+incorporate functionality developed for the [Scaife
+Viewer](https://scaife.perseus.org/) and [Beyond
+Translation](https://beyond-translation.perseus.org/reader/urn:cts:engLit:mds822-32.tpsthl-1599.pdl-eng:1-6)
+prototypes.
+
+Minimum Viable Perseus (MVP) is the core of the new Perseus 6
+architecture.  It is a collection of modules that compile Perseus's
+TEI-encoded XML texts into a static website of interlinked HTML pages
+navigable without JavaScript or a backend database.
+
+### What MVP Produces
+
+- **Static HTML pages** — TEI texts rendered as a three-column reader
+  (table of contents, text, annotations), chunked by
+  structural division or milestone
+
+- **Basic Catalog pages** - Simple browsable lists of available texts
+
+These are meant to be served on the web via a simple HTTP server.
+
+### How MVP Works
+MVP components are meant to be used in a compilation pipeline.
+
+**TEI --> word indexes** - Indexers generate word indexes and chunk
+  indexes linking word tokens and chunk elements to XPaths. These
+  indexes are used by NLP modules to create morphological analyses,
+  which may be compiled into the web pages.
+
+**TEI --> citation indexes** - a ReferenceParser is used to generate
+  an index of elements and CTS urns.  This index is used to implement
+  hypertextual linking and passage alignments.
+
+**TEI --> HTML** - XSLT stylesheets are used to generate HTML pages
+  from TEI documents that are "chunked" according to the TEI structure
+  and the document's refsDecls. XSL stylesheets also convert TEI
+  elements into HTML elements, according to the customized TEI schema
+  for the document.
+
+
+### External Services
+Because MVP is a static site, it has no built-in back-end server or
+database. Some services, however, like full-text searching and word
+study, are best implemented with the aid of databases. MVP is
+designed, therefore, to be compiled (optionally) with links to
+independent servers that can provide these functions.
+
+The first of these is a morph-server, which implements an API that
+returns morphological analyses.
+
+
+### Tools and Utilities
+Perseus's TEI text base has been developed over many years and needs
+to be cleaned up before it can be used properly by Perseus 6. Several
+auditors and linters are being developed to assist in that effort.
+
+There are also several scripts that may be run to generate output:
+
+| Script | Role |
+|------------|------|
+| `run_audit.py` | Corpus runner for `StructureAuditor` and `ReferenceAuditor`; writes JSON reports |
+| `run_build.py` | Builds the site |
+
+
+### Major Modules and Their Roles
+
+#### XSLT
+
+XSLT stylesheets live under `src/xslt/`.
+
+| Stylesheet | Role |
+|------------|------|
+| `xslt/add_xml_ids.xsl`         | Preparation pass: add stable `xml:id` to citable elements (obsolete) |
+| `xslt/tokenize.xsl`            | Extract word tokens as `<tokens>/<token>` document (obsolete) |
+| `html/generate_div_chunks.xsl` | Chunk TEI by `<div>` structure into HTML pages |
+| `html/generate_chunks.xsl`     | Chunk TEI by `<milestone>` elements into HTML pages |
+| `html/chunker_core.xsl`        | Shared CSS design system and templates imported by both chunkers |
+| `html/driver.xsl`              | A stub driver file for combining  TEI->HTML XSL stylesheets     |
+| `html/variables.xsl`           | The start of a file to hold variables common to all stylesheets     |
+| `html/tei/*.xsl`               | Stylesheets tailored to cover elements and attributes defined in Perseus TEI custom schemas     |
+
+
+`xslt/add_xml_ids.xsl` and `xslt/tokenize.xsl` are obsolete, because we are shifting to a new workflow that uses indexers.
+
+#### Python
+Almost all source code lives under `src/python/`.  The primary package is
+`mvp/`.
+
+| Module | Role |
+|--------|------|
+| `mvp/auditors.py` | `StructureAuditor`, `ReferenceAuditor` — analyze TEI document structure and `refsDecl` declarations |
+| `mvp/compilers.py` | PageCompiler and CatalogCompiler. Other compilation activities should get their own classes here. |
+| `mvp/corpus.py` | the Corpus object discovers and enumerates TEI source documents (TEIDocuments) under a root directory |
+| `mvp/document.py` | One version of the TEIDocument class, with extracted metadata |
+| `mvp/indexers.py` | `TEIIndexer`, `WordIndexer`, `ChunkIndexer` — extract word tokens and chunk elements with XPath provenance for NLP pipelines |
+| `mvp/linters.py` | Probably obsolete |
+| `mvp/tei_document.py` | Thin TEI wrapper with recover-mode parser; shared by auditors and normalizers |
+| `mvp/models.py`| Core data objects for the build pipeline |
+| `mvp/normalizers.py` | Phases 2 and 3 of the citation pipeline: repair `xml:base`, add `xml:id` (status: possibly superseded by `citeStructure` approach; retained pending decision) |
+| `mvp/pipeline.py` | BuildPipeline : orchestrates the site build |
+| `mvp/site_map.py` | owns the output path and URL scheme for all compiled artifacts |
+| `mvp/strategy.py` | ChunkingStrategy and StrategySelector  |
+| `run_build.py` | Builds the site |
+| `run_audit.py` | Corpus runner for `StructureAuditor` and `ReferenceAuditor`; writes JSON reports |
+| `tei_citation_pipeline.py` | CLI wrapper (legacy entry point; logic now in `auditors.py` and `normalizers.py`) |
+
+
+There is also code outside the `mvp` package.
+
+| Module | Role |
+|--------|------|
+|`src/python/run_audit.py` | commandline script to run audits on a Perseus corpus |
+|`src/python/tei_citation_pipeline.py`       | an older script that combined auditing, normalizing, and adding xml ids. `run_audit.py` has been refactored out of it; the other tasks have been moved to `mvp/normalizers.py`.  This is ripe for cleanup.     |
+|`/src/python/utils/*.py`       | Developed before the auditor tools; these scripts should be looked at to see if they are still needed.     |
+
+
+There is also an implementation of a simple morphological server at
+`src/morph-server`. It was developed independently by a different
+developer (Peter Nadel), and should probably be incorporated into the
+rest of the MVP code base; however, a case could be made for keeping
+it separate, as an "external service". We do not need to decide this now, however.
+
+
+### Active Development
+
+The following areas are currently under active development (see
+`forum.org` for the full deliberative record and current TODO items):
+
+- **Citation infrastructure**: `ReferenceParser` implementation
+  (resolves/generates CTS URNs via `<citeStructure>`); migration of
+  corpus from `<cRefPattern>` to `<citeStructure>` (design phase)
+- **XSLT modularization**: refactoring chunker stylesheets into a
+  proper stylesheet family (see `#reimplement-xslt-to-be-modular`)
+
+
+### Deferred / Out of Scope for MVP
+
+- Full-text search (delegated to external systems)
+- Dynamic morphological analysis at request time (delegated; MVP
+  provides the data, not the service)
+- SpaCy integration at corpus scale (experimental branch exists;
+  not yet merged or designed for production)
+- Bekker citation support (design agreed; implementation deferred)
+
+
+## Corpora
+
+The primary corpora are kept in GitHub repositories:
+
+- [canonical-greekLit](https://github.com/PerseusDL/canonical-greekLit)
+- [canonical-latinLit](https://github.com/PerseusDL/canonical-latinLit)
+- [csel-dev](https://github.com/OpenGreekAndLatin/csel-dev)
+- [First1KGreek](https://github.com/OpenGreekAndLatin/First1KGreek)
+- [canonical-pdlrefwk](https://github.com/PerseusDL/canonical-pdlrefwk) - reference works (public)
+- [canonical_pdlrefwk](https://github.com/PerseusDL/canonical_pdlrefwk) - reference works (private)
+- [lexica](https://github.com/PerseusDL/lexica) - Greek and Latin lexica
+
+Note that the layout of these data repositories varies. Corpus-traversal code needs to be customized for each.
+
+`canonical_greekLit` and `canonical-latinLit` do share the same
+structure: they contain a `data/` subdirectory that contains
+hierarchical subdirectories organized in the pattern of cts urns.
+When traversing these directories for processing, beware of
+__cts__.xml metadata files.
+
+
+## Further Reading
+
+- `wiki/` — project wiki: standards, workflows, CTS
+  URN architecture, chunking design
+- `forum.org` — deliberative record: research, decisions,
+  implementation notes for all significant work items
+- `.claude/guidelines/` — coding conventions; read before any coding
+  task
+- `docs/Cayless_et_al_-_Introducing_Citation_Structures.pdf` —
+  background reading for citation infrastructure work
+

--- a/.claude/guidelines/collaboration-protocol.org
+++ b/.claude/guidelines/collaboration-protocol.org
@@ -235,21 +235,65 @@ architectural changes.  Adds a Review checkpoint between Implementation
 and DONE.
 
 #+begin_example
-1. Claude Code completes implementation; writes Implementation section;
+1. Claude Code creates feature branch (or works on one Cliff has
+   already created — see Git Conventions below)
+2. Claude Code completes implementation; writes Implementation section;
    sets keyword to REVIEW
-2. Cliff uploads key files to Claude Chat
-3. Claude Chat writes Review section (interface conformance, design
+3. Cliff uploads key files to Claude Chat
+4. Claude Chat writes Review section (interface conformance, design
    concerns, notes for future implementors)
-4. Cliff pastes Review section into forum.org
-5. If Review approves: Cliff sets keyword to DONE
+5. Cliff pastes Review section into forum.org
+6. If Review approves: Cliff merges branch, sets keyword to DONE,
+   records commit hash in COMMIT property
    If Review requests fixes: Claude Code addresses them, updates
-   Implementation section, Cliff sets back to REVIEW for a second pass
+   Implementation section; Cliff sets back to REVIEW for a second pass
 #+end_example
 
 The Review section is written by Claude Chat because it has the design
 context from the Research phase.  Claude Code's self-report in
 Implementation is not a substitute: it records what was done, not
 whether the design was followed faithfully.
+
+* Git Conventions
+
+** Feature branches
+
+All implementation work happens on a feature branch cut from =dev=,
+never directly on =dev= or =main=.  Branch names should follow the
+pattern =feature/CUSTOM_ID-short-description=, e.g.
+=feature/refactor-citation-pipeline=.
+
+Note: *before starting work, Claude Code must check whether Cliff has
+already created the branch.*  Cliff sometimes creates the branch in
+advance — particularly when he has already made preparatory edits.
+Claude Code should run =git branch -a= or check with Cliff rather than
+assuming the branch does not exist.
+
+When the branch does not yet exist, Claude Code creates it:
+
+#+begin_example
+git checkout dev
+git pull
+git checkout -b feature/my-task-slug
+#+end_example
+
+** When to mark a task DONE
+
+A task moves from REVIEW to DONE only when all of the following are
+true:
+
+1. The Review section is present and contains an explicit approval from
+   Claude Chat (or Cliff, for tasks that did not require Claude Chat
+   review).
+2. Any fixes requested in the Review have been addressed and noted in
+   the Implementation section.
+3. The feature branch has been merged into =dev= and the merge commit
+   hash recorded in the =COMMIT= property.
+4. All tests pass on =dev= after the merge.
+
+Claude Code should not self-approve by setting a task to DONE after
+writing its own Implementation section.  The state transition to DONE
+is Cliff's action, taken after the Review is complete.
 
 * Handoff Conventions
 
@@ -282,18 +326,6 @@ Questions for Claude Chat:
 - What does the spec/standard say about Z?
 #+end_example
 
-** From either AI to Cliff
-
-Open questions requiring Cliff's judgment should always be explicit
-and clearly separated from analysis:
-
-#+begin_example
-Open questions:
-- Preferred approach: A (simpler) or B (more robust)?
-- Priority relative to other work?
-- Any constraints from stakeholders?
-#+end_example
-
 ** From Claude Code to Claude Chat (review request)
 
 When Claude Code sets a task to REVIEW, the Implementation section
@@ -311,6 +343,18 @@ Ready for review:
 This is not a comprehensive change log (that belongs in the git commit
 message) but a navigation guide for the reviewer, who has design context
 but not codebase access.
+
+** From either AI to Cliff
+
+Open questions requiring Cliff's judgment should always be explicit
+and clearly separated from analysis:
+
+#+begin_example
+Open questions:
+- Preferred approach: A (simpler) or B (more robust)?
+- Priority relative to other work?
+- Any constraints from stakeholders?
+#+end_example
 
 * What This Protocol Does Not Cover
 

--- a/.claude/guidelines/documentation.md
+++ b/.claude/guidelines/documentation.md
@@ -21,8 +21,8 @@ The rest of the project uses **org-mode** for documentation.
 | File | Purpose |
 |------|---------|
 | `CLAUDE.md` | Project overview and entry point; read first at the start of every session |
-| `guidelines/python.md` | Python packaging and coding conventions |
 | `guidelines/documentation.md` | This file |
+| `guidelines/collaboration-protocol.org` | defines protocol for collaboration; read at start of every session |
 
 Design documents (architecture, algorithms, deferred work) belong in the
 project wiki, not in `.claude/`.

--- a/src/python/mvp/reference_parser.py
+++ b/src/python/mvp/reference_parser.py
@@ -96,6 +96,9 @@ class ReferenceParser:
         if not passage:
             raise CitationError(f"URN has no passage component: {urn!r}")
 
+        # The root <citeStructure> is an anchor only: its @match binds <body>
+        # as context and its @use provides the base URN. It is not itself a
+        # citation level, so resolution begins with its children.
         children = list(self._root_cs.findall("tei:citeStructure", NS))
         if not children:
             raise CitationError("Root <citeStructure> has no children to resolve against")
@@ -176,7 +179,11 @@ class ReferenceParser:
             )
         parts: list[str] = []
         for cs, elem in path:
-            delim = cs.get("delim", ":")
+            delim = cs.get("delim")
+            if delim is None:
+                raise ConfigurationError(
+                    f"<citeStructure unit={cs.get('unit')!r}> is missing required @delim"
+                )
             use_attr = cs.get("use", "@n")
             val = elem.get(use_attr[1:], "") if use_attr.startswith("@") else ""
             parts.append(delim + val)
@@ -188,6 +195,9 @@ class ReferenceParser:
         parent_cs: etree._Element,
         context: etree._Element,
     ) -> Optional[list[tuple[etree._Element, etree._Element]]]:
+        # The root <citeStructure>'s @match is never evaluated here: the caller
+        # passes self._body as context and self._root_cs as parent_cs, so we
+        # begin immediately at the root's children (the real citation levels).
         for cs in parent_cs.findall("tei:citeStructure", NS):
             match_expr = cs.get("match", "")
             candidates: list[etree._Element] = context.xpath(match_expr, namespaces=NS)


### PR DESCRIPTION
## Summary

- Raise `ConfigurationError` in `generate()` when a child `<citeStructure>` is missing `@delim`, preventing silent production of malformed URNs (previously fell back silently to `":"`)
- Add comment in `resolve()` explaining that the root `<citeStructure>` is an anchor only and resolution begins with its children
- Add comment in `_find_path_to()` explaining that the root node's `@match` is never evaluated during generation

Addresses the three MINOR items from the Claude Chat review recorded in `forum.org` under `#implement-reference-parser`.

## Test plan

- [ ] All 21 existing `tests/test_reference_parser.py` tests pass (`pytest tests/test_reference_parser.py`)
- [ ] No new tests required — the delimiter fix is a correctness guard for misconfigured documents; existing fixtures all supply `@delim` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)