### PR TITLE
Fix ChunkingStrategy/PageCompiler driver wiring

### DIFF
--- a/src/python/mvp/compilers.py
+++ b/src/python/mvp/compilers.py
@@ -22,6 +22,8 @@ from mvp.site_map import SiteMap
 from mvp.strategy import ChunkingStrategy
 
 # Human-readable names for BCP 47 / ISO 639-3 language codes.
+_DRIVER_STYLESHEET = "html/driver.xsl"
+
 _LANGUAGE_NAMES: dict[str, str] = {
     "lat": "Latin",
     "grc": "Greek",
@@ -124,7 +126,7 @@ class PageCompiler:
                               any reason.
         """
         output_path.mkdir(parents=True, exist_ok=True)
-        stylesheet = self._xslt_root / self._strategy.xslt_stylesheet
+        stylesheet = self._xslt_root / _DRIVER_STYLESHEET
 
         if catalog_url is None:
             lang = doc.metadata.language

--- a/src/python/mvp/compilers.py
+++ b/src/python/mvp/compilers.py
@@ -22,8 +22,6 @@ from mvp.site_map import SiteMap
 from mvp.strategy import ChunkingStrategy
 
 # Human-readable names for BCP 47 / ISO 639-3 language codes.
-_DRIVER_STYLESHEET = "html/driver.xsl"
-
 _LANGUAGE_NAMES: dict[str, str] = {
     "lat": "Latin",
     "grc": "Greek",
@@ -91,21 +89,22 @@ class PageCompiler:
     generation to an XSLT 3.0 stylesheet via Saxon.
 
     Args:
-        strategy:   ChunkingStrategy determining how the document is
-                    divided into chunks.
-        xslt_root:  Directory containing XSLT stylesheets.
+        strategy:  ChunkingStrategy determining how the document is
+                   divided into chunks.
+        driver:    Full path to the XSLT driver stylesheet (e.g.
+                   Path("src/xslt/html/driver.xsl")).
 
     Usage::
 
-        compiler = PageCompiler(strategy, xslt_root=Path("src/xslt"))
+        compiler = PageCompiler(strategy, driver=Path("src/xslt/html/driver.xsl"))
         compiler.compile(doc, output_path=site_map.chunk_dir(doc.metadata.urn))
     """
 
     def __init__(self, strategy: ChunkingStrategy,
-                 xslt_root: Path,
+                 driver: Path,
                  morph_url: str = "") -> None:
         self._strategy = strategy
-        self._xslt_root = Path(xslt_root)
+        self._driver = Path(driver)
         self._morph_url = morph_url
 
     def compile(self, doc: TEIDocument, output_path: Path,
@@ -126,7 +125,7 @@ class PageCompiler:
                               any reason.
         """
         output_path.mkdir(parents=True, exist_ok=True)
-        stylesheet = self._xslt_root / _DRIVER_STYLESHEET
+        stylesheet = self._driver
 
         if catalog_url is None:
             lang = doc.metadata.language

--- a/src/python/mvp/pipeline.py
+++ b/src/python/mvp/pipeline.py
@@ -35,15 +35,15 @@ class BuildPipeline:
     Args:
         corpus:    The TEI source corpus.
         site_map:  URL/path scheme for compiled artifacts.
-        xslt_root: Directory containing XSLT stylesheets.
+        driver:    Full path to the XSLT driver stylesheet.
     """
 
     def __init__(self, corpora: list[Corpus], site_map: SiteMap,
-                 xslt_root: Path,
+                 driver: Path,
                  morph_url: str = "") -> None:
         self._corpora = corpora
         self._site_map = site_map
-        self._xslt_root = xslt_root
+        self._driver = Path(driver)
         self._morph_url = morph_url
         self._selector = StrategySelector()
 
@@ -66,7 +66,7 @@ class BuildPipeline:
                     strategy = self._selector.select(doc)
                     compiler = PageCompiler(
                         strategy=strategy,
-                        xslt_root=self._xslt_root,
+                        driver=self._driver,
                         morph_url=self._morph_url,
                     )
                     output_path = self._site_map.chunk_dir(doc.metadata.urn)

--- a/src/python/mvp/strategy.py
+++ b/src/python/mvp/strategy.py
@@ -57,12 +57,6 @@ class ChunkingStrategy(ABC):
 
     @property
     @abstractmethod
-    def xslt_stylesheet(self) -> str:
-        """Filename of the XSLT stylesheet that implements this strategy."""
-        ...
-
-    @property
-    @abstractmethod
     def chunk_strategy(self) -> str:
         """Value of the chunk-strategy parameter passed to driver.xsl."""
         ...
@@ -88,10 +82,6 @@ class MilestoneStrategy(ChunkingStrategy):
     @property
     def chunk_unit(self) -> str:
         return self._unit
-
-    @property
-    def xslt_stylesheet(self) -> str:
-        return "html/driver.xsl"
 
     @property
     def chunk_strategy(self) -> str:
@@ -120,10 +110,6 @@ class DivisionStrategy(ChunkingStrategy):
     @property
     def chunk_unit(self) -> str:
         return self._subtype if self._subtype else self._div_type
-
-    @property
-    def xslt_stylesheet(self) -> str:
-        return "html/driver.xsl"
 
     @property
     def chunk_strategy(self) -> str:

--- a/tests/test_compilers.py
+++ b/tests/test_compilers.py
@@ -107,12 +107,12 @@ class TestCompilationError:
 
 class TestPageCompilerConstruction:
 
-    def test_accepts_strategy_and_xslt_root(self, tmp_path, card_strategy):
-        compiler = PageCompiler(strategy=card_strategy, xslt_root=tmp_path)
+    def test_accepts_strategy_and_driver(self, tmp_path, card_strategy):
+        compiler = PageCompiler(strategy=card_strategy, driver=tmp_path / "driver.xsl")
         assert compiler is not None
 
-    def test_xslt_root_coerced_to_path(self, tmp_path, card_strategy):
-        compiler = PageCompiler(strategy=card_strategy, xslt_root=str(tmp_path))
+    def test_driver_coerced_to_path(self, tmp_path, card_strategy):
+        compiler = PageCompiler(strategy=card_strategy, driver=str(tmp_path / "driver.xsl"))
         # No public accessor, but construction must not raise
         assert compiler is not None
 
@@ -124,7 +124,7 @@ class TestPageCompilerCompile:
         output_path = tmp_path / "output" / "deep" / "path"
         assert not output_path.exists()
 
-        compiler = PageCompiler(strategy=card_strategy, xslt_root=tmp_path)
+        compiler = PageCompiler(strategy=card_strategy, driver=tmp_path / "driver.xsl")
         compiler.compile(seneca_doc, output_path)
 
         assert output_path.is_dir()
@@ -132,14 +132,13 @@ class TestPageCompilerCompile:
     def test_invokes_saxon_with_correct_stylesheet(self, tmp_path, seneca_doc,
                                                    card_strategy, mock_saxon):
         mock_cls, mock_proc = mock_saxon
-        xslt_root = tmp_path / "xslt"
-        xslt_root.mkdir()
+        driver = tmp_path / "html" / "driver.xsl"
 
-        compiler = PageCompiler(strategy=card_strategy, xslt_root=xslt_root)
+        compiler = PageCompiler(strategy=card_strategy, driver=driver)
         compiler.compile(seneca_doc, tmp_path / "out")
 
         mock_proc.new_xslt30_processor().compile_stylesheet.assert_called_once_with(
-            stylesheet_file=str(xslt_root / "html/driver.xsl")
+            stylesheet_file=str(driver)
         )
 
     def test_sets_chunk_unit_parameter(self, tmp_path, seneca_doc,
@@ -147,7 +146,7 @@ class TestPageCompilerCompile:
         mock_cls, mock_proc = mock_saxon
         transformer = mock_proc.new_xslt30_processor().compile_stylesheet()
 
-        compiler = PageCompiler(strategy=card_strategy, xslt_root=tmp_path)
+        compiler = PageCompiler(strategy=card_strategy, driver=tmp_path / "driver.xsl")
         compiler.compile(seneca_doc, tmp_path / "out")
 
         calls = [str(c) for c in transformer.set_parameter.call_args_list]
@@ -158,7 +157,7 @@ class TestPageCompilerCompile:
         mock_cls, mock_proc = mock_saxon
         transformer = mock_proc.new_xslt30_processor().compile_stylesheet()
 
-        compiler = PageCompiler(strategy=card_strategy, xslt_root=tmp_path)
+        compiler = PageCompiler(strategy=card_strategy, driver=tmp_path / "driver.xsl")
         compiler.compile(seneca_doc, tmp_path / "out")
 
         calls = [str(c) for c in transformer.set_parameter.call_args_list]
@@ -170,7 +169,7 @@ class TestPageCompilerCompile:
         transformer = mock_proc.new_xslt30_processor().compile_stylesheet()
         output_path = tmp_path / "out"
 
-        compiler = PageCompiler(strategy=card_strategy, xslt_root=tmp_path)
+        compiler = PageCompiler(strategy=card_strategy, driver=tmp_path / "driver.xsl")
         compiler.compile(seneca_doc, output_path)
 
         calls = [str(c) for c in transformer.set_parameter.call_args_list]
@@ -178,7 +177,7 @@ class TestPageCompilerCompile:
 
     def test_returns_none_on_success(self, tmp_path, seneca_doc,
                                      card_strategy, mock_saxon):
-        compiler = PageCompiler(strategy=card_strategy, xslt_root=tmp_path)
+        compiler = PageCompiler(strategy=card_strategy, driver=tmp_path / "driver.xsl")
         result = compiler.compile(seneca_doc, tmp_path / "out")
         assert result is None
 
@@ -190,7 +189,7 @@ class TestPageCompilerCompile:
         mock_proc.new_xslt30_processor().compile_stylesheet(
         ).transform_to_string.side_effect = RuntimeError("Saxon exploded")
 
-        compiler = PageCompiler(strategy=card_strategy, xslt_root=tmp_path)
+        compiler = PageCompiler(strategy=card_strategy, driver=tmp_path / "driver.xsl")
 
         with pytest.raises(CompilationError) as exc_info:
             compiler.compile(seneca_doc, tmp_path / "out")
@@ -206,7 +205,7 @@ class TestPageCompilerCompile:
         mock_proc.new_xslt30_processor().compile_stylesheet(
         ).transform_to_string.side_effect = RuntimeError("oops")
 
-        compiler = PageCompiler(strategy=card_strategy, xslt_root=tmp_path)
+        compiler = PageCompiler(strategy=card_strategy, driver=tmp_path / "driver.xsl")
 
         with pytest.raises(CompilationError) as exc_info:
             compiler.compile(seneca_doc, tmp_path / "out")
@@ -382,7 +381,7 @@ class TestCatalogCompilerIndex:
 # PageCompiler integration tests (require real Saxon + XSLT)
 # ---------------------------------------------------------------------------
 
-XSLT_ROOT = Path(__file__).parent.parent / "src" / "xslt"
+DRIVER = Path(__file__).parent.parent / "src" / "xslt" / "html" / "driver.xsl"
 DTD_FIXTURE_PATH = DATA_DIR / "dtd_entity_test.xml"
 
 
@@ -398,7 +397,7 @@ class TestPageCompilerIntegration:
     def test_seneca_produces_chunks(self, tmp_path):
         doc = TEIDocument.from_path(SENECA_PATH)
         strategy = MilestoneStrategy(unit="card")
-        compiler = PageCompiler(strategy=strategy, xslt_root=XSLT_ROOT)
+        compiler = PageCompiler(strategy=strategy, driver=DRIVER)
         compiler.compile(doc, tmp_path)
 
         assert (tmp_path / "card_1.html").exists(), \
@@ -412,7 +411,7 @@ class TestPageCompilerIntegration:
     def test_seneca_chunk_contains_html_structure(self, tmp_path):
         doc = TEIDocument.from_path(SENECA_PATH)
         strategy = MilestoneStrategy(unit="card")
-        compiler = PageCompiler(strategy=strategy, xslt_root=XSLT_ROOT)
+        compiler = PageCompiler(strategy=strategy, driver=DRIVER)
         compiler.compile(doc, tmp_path)
 
         html = (tmp_path / "card_1.html").read_text(encoding="utf-8")
@@ -428,7 +427,7 @@ class TestPageCompilerIntegration:
         """generate_chunks.xsl must write a toc.html alongside index.json."""
         doc = TEIDocument.from_path(SENECA_PATH)
         strategy = MilestoneStrategy(unit="card")
-        compiler = PageCompiler(strategy=strategy, xslt_root=XSLT_ROOT)
+        compiler = PageCompiler(strategy=strategy, driver=DRIVER)
         compiler.compile(doc, tmp_path)
 
         assert (tmp_path / "toc.html").exists(), "Expected toc.html to be produced"
@@ -440,7 +439,7 @@ class TestPageCompilerIntegration:
         """Documents with DOCTYPE references compile after the DTD parser fix."""
         doc = TEIDocument.from_path(DTD_FIXTURE_PATH)
         strategy = MilestoneStrategy(unit="section")
-        compiler = PageCompiler(strategy=strategy, xslt_root=XSLT_ROOT)
+        compiler = PageCompiler(strategy=strategy, driver=DRIVER)
         compiler.compile(doc, tmp_path)
 
         assert (tmp_path / "section_1.html").exists()
@@ -458,7 +457,7 @@ class TestPageCompilerIntegration:
         from mvp.strategy import DivisionStrategy
         doc = TEIDocument.from_path(DATA_DIR / "phi2331.phi013.perseus-lat2.xml")
         strategy = DivisionStrategy(div_type="textpart", subtype="chapter")
-        compiler = PageCompiler(strategy=strategy, xslt_root=XSLT_ROOT)
+        compiler = PageCompiler(strategy=strategy, driver=DRIVER)
         compiler.compile(doc, tmp_path)
 
         assert (tmp_path / "chapter_1.html").exists()
@@ -474,7 +473,7 @@ class TestPageCompilerIntegration:
         """PageCompiler.compile() must inject author and language into index.json."""
         doc = TEIDocument.from_path(DATA_DIR / "phi1017.phi007.perseus-lat2.xml")
         strategy = MilestoneStrategy(unit="card")
-        compiler = PageCompiler(strategy=strategy, xslt_root=XSLT_ROOT)
+        compiler = PageCompiler(strategy=strategy, driver=DRIVER)
         compiler.compile(doc, tmp_path)
 
         manifest = json.loads((tmp_path / "index.json").read_text())

--- a/tests/test_compilers.py
+++ b/tests/test_compilers.py
@@ -139,7 +139,7 @@ class TestPageCompilerCompile:
         compiler.compile(seneca_doc, tmp_path / "out")
 
         mock_proc.new_xslt30_processor().compile_stylesheet.assert_called_once_with(
-            stylesheet_file=str(xslt_root / card_strategy.xslt_stylesheet)
+            stylesheet_file=str(xslt_root / "html/driver.xsl")
         )
 
     def test_sets_chunk_unit_parameter(self, tmp_path, seneca_doc,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -100,7 +100,7 @@ def make_pipeline(tmp_path, corpus, selector_side_effect=None,
         pl = BuildPipeline(
             corpora=[corpus],
             site_map=site_map,
-            xslt_root=tmp_path / "xslt",
+            driver=tmp_path / "driver.xsl",
         )
         mock_selector = mock_selector_cls.return_value
 
@@ -130,7 +130,7 @@ class TestBuildPipelineConstruction:
             pl = BuildPipeline(
                 corpora=[corpus_a, corpus_b],
                 site_map=SiteMap(tmp_path / "output"),
-                xslt_root=tmp_path / "xslt",
+                driver=tmp_path / "driver.xsl",
             )
         assert pl is not None
 
@@ -251,7 +251,7 @@ class TestBuildPipelineSuccess:
             pl = BuildPipeline(
                 corpora=[corpus_a, corpus_b],
                 site_map=site_map,
-                xslt_root=tmp_path / "xslt",
+                driver=tmp_path / "driver.xsl",
             )
 
         with patch("mvp.pipeline.PageCompiler") as mock_page_cls, \

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -198,9 +198,6 @@ class TestMilestoneStrategyDescribes:
         assert MilestoneStrategy(unit="section").chunk_unit == "section"
         assert MilestoneStrategy(unit="line").chunk_unit == "line"
 
-    def test_xslt_stylesheet_returns_driver(self):
-        assert MilestoneStrategy(unit="card").xslt_stylesheet == "html/driver.xsl"
-
     def test_chunk_strategy_returns_milestone(self):
         assert MilestoneStrategy(unit="card").chunk_strategy == "milestone"
 
@@ -242,10 +239,6 @@ class TestDivisionStrategyDescribes:
         doc = write_doc(tmp_path, CHAPTER_DIVS_ONLY)
         assert not DivisionStrategy(div_type="textpart",
                                     subtype="scene").describes(doc)
-
-    def test_xslt_stylesheet_returns_driver(self):
-        assert DivisionStrategy(div_type="textpart").xslt_stylesheet == \
-            "html/driver.xsl"
 
     def test_chunk_strategy_returns_div(self):
         assert DivisionStrategy(div_type="textpart").chunk_strategy == "div"


### PR DESCRIPTION
## Summary

Follow-on fixes to PR #71 addressing two bugs in the Python build pipeline:

- **`chunk-strategy` not passed to Saxon**: `PageCompiler` was invoking the chunkers directly (`generate_chunks.xsl`, `generate_div_chunks.xsl`) rather than `driver.xsl`, causing `XTSE0650 page:render not found`. Fixed by pointing both strategies at `driver.xsl` and passing `chunk-strategy` as a parameter.
- **`xslt_stylesheet` abstraction broken**: Both `MilestoneStrategy` and `DivisionStrategy` returned the same hardcoded value `"html/driver.xsl"`, defeating the purpose of the abstract property. Removed `xslt_stylesheet` from the strategy hierarchy entirely.
- **Driver path hardcoded**: `"html/driver.xsl"` was then hardcoded as a module constant in `compilers.py`. Replaced with a `driver: Path` parameter on `PageCompiler` and `BuildPipeline`, consistent with how `generate_html_from_tei.py` accepts the stylesheet path from the caller.

## Test plan

- [ ] 314 unit tests pass (`pdm run test`)
- [ ] `PageCompiler(strategy, driver=Path("src/xslt/html/driver.xsl")).compile(doc, out)` runs without `XTSE0650`
- [ ] `BuildPipeline(corpora, site_map, driver=Path("src/xslt/html/driver.xsl")).run()` compiles a corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)