### PR TITLE
Implement CitationResolver (#55)

### DIFF
--- a/src/python/mvp/citation_resolver.py
+++ b/src/python/mvp/citation_resolver.py
@@ -1,12 +1,85 @@
+from __future__ import annotations
+
 import json
 from pathlib import Path
-from lxml import etree
 
 
 class CitationResolver:
-    def __init__(self) -> None:
-        pass
+    """Resolves classical citation strings to CTS URNs.
 
-    
-    def resolve(self, citation:str) -> str:
-        pass
+    Ported from Charles Pletcher's citation-resolution module
+    (https://github.com/PerseusDLCode/citation-resolution).
+
+    Args:
+        abbreviations_dir: Directory containing ocd_abbreviations.json
+                           and inverted_urn.json.
+
+    Usage::
+
+        resolver = CitationResolver(Path("data/abbreviations"))
+        urn = resolver.resolve("Hom. Od. 1.1")
+        # -> "urn:cts:greekLit:tlg0012.tlg002:1.1"
+    """
+
+    def __init__(self, abbreviations_dir: Path) -> None:
+        abbreviations_dir = Path(abbreviations_dir)
+
+        abbrevs_list: list[dict] = json.loads(
+            (abbreviations_dir / "ocd_abbreviations.json").read_text(encoding="utf-8")
+        )
+        self._abbreviations: dict[str, list[str]] = {}
+        for entry in abbrevs_list:
+            self._abbreviations.setdefault(entry["abbrev"], []).append(entry["full"])
+
+        self._inverted_urns: dict[str, dict[str, str]] = json.loads(
+            (abbreviations_dir / "inverted_urn.json").read_text(encoding="utf-8")
+        )
+
+    def resolve(self, citation: str) -> str | None:
+        """Resolve a citation string to a CTS URN with location.
+
+        Citation format: "AUTHOR_ABBREV [WORK_ABBREV] LOCATION"
+        where author and work are standard scholarly abbreviations.
+
+        Returns the CTS URN string ("urn:cts:...:location"), or None if
+        the author, work, or URN cannot be resolved.
+        """
+        parts = citation.split()
+        if len(parts) < 2:
+            return None
+
+        author_abbrev = parts[0]
+        location = parts[-1]
+        work_abbrev = " ".join(parts[1:-1])
+
+        if not work_abbrev:
+            return None
+
+        author_full = self._expand(author_abbrev)
+        if author_full is None:
+            return None
+
+        author_dict = self._inverted_urns.get(author_full.lower())
+        if author_dict is None:
+            return None
+
+        work_full = self._expand(work_abbrev)
+        if work_full is None:
+            return None
+
+        cts_urn = author_dict.get(work_full.lower())
+
+        if cts_urn is None:
+            prefix = work_full.lower()
+            matches = [v for k, v in author_dict.items() if k.startswith(prefix)]
+            cts_urn = matches[0] if matches else None
+
+        if cts_urn is None:
+            return None
+
+        return f"{cts_urn}:{location}"
+
+    def _expand(self, abbreviation: str) -> str | None:
+        """Return the first full expansion of abbreviation, or None."""
+        matches = self._abbreviations.get(abbreviation, [])
+        return matches[0] if matches else None

--- a/src/python/mvp/citation_resolver.py
+++ b/src/python/mvp/citation_resolver.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+from lxml import etree
+
+
+class CitationResolver:
+    def __init__(self) -> None:
+        pass
+
+    
+    def resolve(self, citation:str) -> str:
+        pass

--- a/tests/test_citation_resolver.py
+++ b/tests/test_citation_resolver.py
@@ -1,0 +1,119 @@
+# tests/test_citation_resolver.py
+#
+# Tests for CitationResolver.
+#
+# Uses small synthetic fixture data written to tmp_path rather than the
+# real data files in data/abbreviations/ (which are gitignored and not
+# guaranteed to be present in all environments).
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mvp.citation_resolver import CitationResolver
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+ABBREVIATIONS = [
+    {"abbrev": "Hom.", "full": "Homer"},
+    {"abbrev": "Od.",  "full": "Odyssey"},
+    {"abbrev": "Il.",  "full": "Iliad"},
+    {"abbrev": "Pl.",  "full": "Plato"},
+    {"abbrev": "Rep.", "full": "Republic"},
+    # Duplicate abbreviation — first entry wins
+    {"abbrev": "Cat.", "full": "In Catilinam"},
+    {"abbrev": "Cat.", "full": "Catalogus mulierum"},
+]
+
+INVERTED_URNS = {
+    "homer": {
+        "odyssey": "urn:cts:greekLit:tlg0012.tlg002",
+        "iliad":   "urn:cts:greekLit:tlg0012.tlg001",
+    },
+    "plato": {
+        "republic": "urn:cts:greekLit:tlg0059.tlg030",
+    },
+}
+
+
+@pytest.fixture
+def abbreviations_dir(tmp_path: Path) -> Path:
+    (tmp_path / "ocd_abbreviations.json").write_text(
+        json.dumps(ABBREVIATIONS), encoding="utf-8"
+    )
+    (tmp_path / "inverted_urn.json").write_text(
+        json.dumps(INVERTED_URNS), encoding="utf-8"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def resolver(abbreviations_dir: Path) -> CitationResolver:
+    return CitationResolver(abbreviations_dir)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+class TestCitationResolverConstruction:
+
+    def test_accepts_path(self, abbreviations_dir):
+        r = CitationResolver(abbreviations_dir)
+        assert r is not None
+
+    def test_accepts_string_path(self, abbreviations_dir):
+        r = CitationResolver(str(abbreviations_dir))
+        assert r is not None
+
+    def test_raises_on_missing_dir(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            CitationResolver(tmp_path / "nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# resolve()
+# ---------------------------------------------------------------------------
+
+class TestResolve:
+
+    def test_known_author_and_work(self, resolver):
+        assert resolver.resolve("Hom. Od. 1.1") == \
+            "urn:cts:greekLit:tlg0012.tlg002:1.1"
+
+    def test_multi_digit_location(self, resolver):
+        assert resolver.resolve("Hom. Il. 24.804") == \
+            "urn:cts:greekLit:tlg0012.tlg001:24.804"
+
+    def test_three_token_citation(self, resolver):
+        assert resolver.resolve("Pl. Rep. 514a") == \
+            "urn:cts:greekLit:tlg0059.tlg030:514a"
+
+    def test_unknown_author_returns_none(self, resolver):
+        assert resolver.resolve("Xen. An. 1.1") is None
+
+    def test_unknown_work_returns_none(self, resolver):
+        assert resolver.resolve("Hom. Batr. 1") is None
+
+    def test_unknown_abbreviation_returns_none(self, resolver):
+        assert resolver.resolve("Zzz. Yyy. 1.1") is None
+
+    def test_single_token_returns_none(self, resolver):
+        assert resolver.resolve("Hom.") is None
+
+    def test_two_tokens_no_work_returns_none(self, resolver):
+        # "Hom. 1.1" — no work abbreviation between author and location
+        assert resolver.resolve("Hom. 1.1") is None
+
+    def test_empty_string_returns_none(self, resolver):
+        assert resolver.resolve("") is None
+
+    def test_first_expansion_wins_for_duplicate_abbreviation(self, resolver):
+        # "Cat." expands to "In Catilinam" (first entry); not in inverted_urns -> None
+        assert resolver.resolve("Cat. 1.1") is None


### PR DESCRIPTION
## Summary

- Ports Charles Pletcher's citation-resolution module into the MVP codebase as `src/python/mvp/citation_resolver.py`
- `CitationResolver.__init__` takes an explicit `abbreviations_dir: Path` (no hardcoded paths, consistent with MVP conventions)
- `resolve(citation: str) -> str | None` parses "AUTHOR WORK LOCATION" strings, expands abbreviations via `ocd_abbreviations.json`, looks up CTS URNs in `inverted_urn.json`, and returns `None` on failure rather than degraded fallback strings
- 13 tests in `tests/test_citation_resolver.py` using synthetic fixture data (no dependency on local data files)

Closes #55.

## Test plan

- [ ] `pdm run test` — 322 unit tests pass
- [ ] `CitationResolver(Path("data/abbreviations")).resolve("Hom. Od. 1.1")` returns `urn:cts:greekLit:tlg0012.tlg002:1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)