### PR TITLE
Add nlp_pipeline.py for including token-level annotations

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "morph"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:312cd6e16b4b61084a2912cac71b9c7126221d82e0c8d6866984e11811d54366"
+content_hash = "sha256:a18044d19c7e5fa75ff654b89b829f612fef840a0735af94b9fee18d4730c0d8"
 
 [[metadata.targets]]
 requires_python = ">=3.12"
@@ -49,6 +49,92 @@ dependencies = [
 files = [
     {file = "anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"},
     {file = "anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"},
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+requires_python = ">=3.7"
+summary = "Python package for providing Mozilla's CA Bundle."
+groups = ["default"]
+files = [
+    {file = "certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897"},
+    {file = "certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"},
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+requires_python = ">=3.7"
+summary = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+groups = ["default"]
+files = [
+    {file = "charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d"},
+    {file = "charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"},
+    {file = "charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"},
 ]
 
 [[package]]
@@ -926,6 +1012,23 @@ files = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+requires_python = ">=3.10"
+summary = "Python HTTP for Humans."
+groups = ["default"]
+dependencies = [
+    "certifi>=2023.5.7",
+    "charset-normalizer<4,>=2",
+    "idna<4,>=2.5",
+    "urllib3<3,>=1.26",
+]
+files = [
+    {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
+    {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 requires_python = ">=3.7"
@@ -1037,6 +1140,17 @@ marker = "sys_platform == \"emscripten\" or sys_platform == \"win32\""
 files = [
     {file = "tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7"},
     {file = "tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10"},
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+requires_python = ">=3.10"
+summary = "HTTP library with thread-safe connection pooling, file post, and more."
+groups = ["default"]
+files = [
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Cliff Wulfman", email = "cwulfman@princeton.edu"},
     {name = "Charles Pletcher", email = "charles.pletcher@gmail.com"}
 ]
-dependencies = ["lxml>=6.0.4", "lxml-stubs>=0.5.1", "saxonche>=12.9.0", "pandas>=3.0.2", "fastapi>=0.136.1", "uvicorn[standard]>=0.46.0"]
+dependencies = ["lxml>=6.0.4", "lxml-stubs>=0.5.1", "saxonche>=12.9.0", "pandas>=3.0.2", "fastapi>=0.136.1", "uvicorn[standard]>=0.46.0", "requests>=2.34.2"]
 requires-python = ">=3.12"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/python/mvp/compilers.py
+++ b/src/python/mvp/compilers.py
@@ -43,7 +43,9 @@ _SHARED_CSS = """
                font-size: .8em; color: #888; text-align: center }
 """
 
-_CATALOG_CSS = _SHARED_CSS + """
+_CATALOG_CSS = (
+    _SHARED_CSS
+    + """
 body         { font-family: serif; max-width: 60em; margin: 0 auto; padding: 1em 2em }
 h1           { margin-bottom: 0.25em }
 .summary     { color: #555; margin-bottom: 1.5em }
@@ -54,14 +56,18 @@ h1           { margin-bottom: 0.25em }
 .work-entry a { text-decoration: none }
 .work-entry a:hover { text-decoration: underline }
 """
+)
 
-_INDEX_CSS = _SHARED_CSS + """
+_INDEX_CSS = (
+    _SHARED_CSS
+    + """
 body  { font-family: serif; max-width: 40em; margin: 0 auto; padding: 2em }
 h1    { margin-bottom: 0.25em }
 .tagline { color: #555; margin-bottom: 1.5em }
 ul    { list-style: none; padding: 0 }
 li    { margin: .5em 0; font-size: 1.1em }
 """
+)
 
 
 @dataclass
@@ -71,6 +77,7 @@ class CompilationError(Exception):
     Carries enough context for the BuildPipeline to log clearly
     and decide whether to continue or abort.
     """
+
     document: TEIDocument
     message: str
     cause: Exception | None = None
@@ -89,26 +96,35 @@ class PageCompiler:
     generation to an XSLT 3.0 stylesheet via Saxon.
 
     Args:
-        strategy:  ChunkingStrategy determining how the document is
-                   divided into chunks.
-        driver:    Full path to the XSLT driver stylesheet (e.g.
-                   Path("src/xslt/html/driver.xsl")).
+        strategy:          ChunkingStrategy determining how the document is
+                           divided into chunks.
+        driver:            Full path to the XSLT driver stylesheet (e.g.
+                           Path("src/xslt/html/driver.xsl")).
+        annotations_file:  Path to the pre-computed NLP annotations JSON
+                           sidecar.  When provided, passed to the stylesheet
+                           as ``annotations-file`` so tokens can be annotated
+                           inline.  Omit to skip NLP annotation.
 
     Usage::
 
-        compiler = PageCompiler(strategy, driver=Path("src/xslt/html/driver.xsl"))
+        compiler = PageCompiler(strategy, driver=Path("src/xslt/html/driver.xsl"),
+                                annotations_file=site_map.annotations_path(urn))
         compiler.compile(doc, output_path=site_map.chunk_dir(doc.metadata.urn))
     """
 
-    def __init__(self, strategy: ChunkingStrategy,
-                 driver: Path,
-                 morph_url: str = "") -> None:
+    def __init__(
+        self,
+        strategy: ChunkingStrategy,
+        driver: Path,
+        annotations_file: Path | None = None,
+    ) -> None:
         self._strategy = strategy
         self._driver = Path(driver)
-        self._morph_url = morph_url
+        self._annotations_file = annotations_file
 
-    def compile(self, doc: TEIDocument, output_path: Path,
-                catalog_url: str | None = None) -> None:
+    def compile(
+        self, doc: TEIDocument, output_path: Path, catalog_url: str | None = None
+    ) -> None:
         """Compile doc into HTML chunk pages written to output_path.
 
         Args:
@@ -134,29 +150,24 @@ class PageCompiler:
         try:
             with PySaxonProcessor(license=False) as proc:
                 xslt = proc.new_xslt30_processor()
-                transformer = xslt.compile_stylesheet(
-                    stylesheet_file=str(stylesheet)
-                )
+                transformer = xslt.compile_stylesheet(stylesheet_file=str(stylesheet))
                 transformer.set_parameter(
-                    "chunk-unit",
-                    proc.make_string_value(self._strategy.chunk_unit)
+                    "chunk-unit", proc.make_string_value(self._strategy.chunk_unit)
                 )
                 transformer.set_parameter(
                     "chunk-strategy",
-                    proc.make_string_value(self._strategy.chunk_strategy)
+                    proc.make_string_value(self._strategy.chunk_strategy),
                 )
                 transformer.set_parameter(
-                    "output-dir",
-                    proc.make_string_value(str(output_path))
+                    "output-dir", proc.make_string_value(str(output_path))
                 )
                 transformer.set_parameter(
-                    "catalog-url",
-                    proc.make_string_value(catalog_url)
+                    "catalog-url", proc.make_string_value(catalog_url)
                 )
-                if self._morph_url:
+                if self._annotations_file:
                     transformer.set_parameter(
-                        "morph-url",
-                        proc.make_string_value(self._morph_url)
+                        "annotations-file",
+                        proc.make_string_value(self._annotations_file.as_uri()),
                     )
                 transformer.set_base_output_uri(output_path.as_uri() + "/")
                 transformer.transform_to_string(source_file=str(doc.path))
@@ -166,7 +177,7 @@ class PageCompiler:
             manifest = output_path / "index.json"
             if manifest.exists():
                 data = json.loads(manifest.read_text(encoding="utf-8"))
-                data["author"]   = doc.metadata.author
+                data["author"] = doc.metadata.author
                 data["language"] = doc.metadata.language
                 manifest.write_text(
                     json.dumps(data, indent=2, ensure_ascii=False),
@@ -197,8 +208,7 @@ class CatalogCompiler:
     def __init__(self, site_map: SiteMap) -> None:
         self._site_map = site_map
 
-    def compile(self, entries: list[TEIMetadata],
-                output_path: Path) -> None:
+    def compile(self, entries: list[TEIMetadata], output_path: Path) -> None:
         """Compile a per-language catalog page and write it to output_path.
 
         Args:
@@ -212,10 +222,14 @@ class CatalogCompiler:
             return
 
         language = entries[0].language
-        lang_name = _LANGUAGE_NAMES.get(language, language.upper() if language else "Unknown")
+        lang_name = _LANGUAGE_NAMES.get(
+            language, language.upper() if language else "Unknown"
+        )
 
         # Sort by author then title.
-        sorted_entries = sorted(entries, key=lambda e: (e.author.lower(), e.title.lower()))
+        sorted_entries = sorted(
+            entries, key=lambda e: (e.author.lower(), e.title.lower())
+        )
 
         # Group by author.
         authors: dict[str, list[TEIMetadata]] = {}
@@ -234,13 +248,13 @@ class CatalogCompiler:
                     rows.append(
                         f'      <div class="work-entry">'
                         f'<a href="{url}">{_escape(work.title)}</a>'
-                        f'</div>'
+                        f"</div>"
                     )
                 else:
                     rows.append(
                         f'      <div class="work-entry">{_escape(work.title)}</div>'
                     )
-            rows.append(f'    </div>')
+            rows.append(f"    </div>")
 
         body = "\n".join(rows)
         count = len(entries)
@@ -275,8 +289,9 @@ class CatalogCompiler:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(html, encoding="utf-8")
 
-    def compile_index(self, languages: dict[str, list[TEIMetadata]],
-                      output_path: Path) -> None:
+    def compile_index(
+        self, languages: dict[str, list[TEIMetadata]], output_path: Path
+    ) -> None:
         """Compile the root index.html linking to each language catalog.
 
         Args:
@@ -292,10 +307,10 @@ class CatalogCompiler:
                 self._site_map.catalog_path(lang), output_path.parent
             ).replace("\\", "/")
             items.append(
-                f'  <li>'
+                f"  <li>"
                 f'<a href="{catalog_url}">{_escape(lang_name)}</a>'
                 f' <span class="count">({count} {noun})</span>'
-                f'</li>'
+                f"</li>"
             )
 
         items_html = "\n".join(items)
@@ -360,8 +375,9 @@ class CatalogCompiler:
 
 def _escape(text: str) -> str:
     """Minimal HTML escaping for text content."""
-    return (text
-            .replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace('"', "&quot;"))
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )

--- a/src/python/mvp/nlp.py
+++ b/src/python/mvp/nlp.py
@@ -1,0 +1,29 @@
+import json
+import os
+
+from pathlib import Path
+
+import requests
+
+from mvp.models import ChunkIndex, ChunkOccurrence
+
+NLP_SERVER_URL = os.getenv("NLP_SERVER_URL", "http://127.0.0.1:8000")
+
+
+def analyze_chunk_index(index: ChunkIndex):
+    return [do_analyze(entry) for entry in index.entries]
+
+
+def do_analyze(entry: ChunkOccurrence):
+    s = entry.chunk
+
+    body = {"content": s}
+
+    resp = requests.post(f"{NLP_SERVER_URL}/analyze", json=body)
+
+    return resp.json()
+
+
+def write_annotations(index: ChunkIndex, path: Path):
+    results = {entry.xpath: do_analyze(entry) for entry in index.entries}
+    path.write_text(json.dumps(results, ensure_ascii=False), encoding="utf-8")

--- a/src/python/mvp/pipeline.py
+++ b/src/python/mvp/pipeline.py
@@ -13,7 +13,9 @@ from pathlib import Path
 from mvp.citation_index import CitationIndexGenerator
 from mvp.compilers import CatalogCompiler, CompilationError, PageCompiler
 from mvp.corpus import Corpus
+from mvp.indexers import ChunkIndexer
 from mvp.models import TEIMetadata
+from mvp.nlp import write_annotations
 from mvp.reference_parser import ConfigurationError
 from mvp.site_map import SiteMap
 from mvp.strategy import StrategySelector
@@ -41,13 +43,15 @@ class BuildPipeline:
         driver:    Full path to the XSLT driver stylesheet.
     """
 
-    def __init__(self, corpora: list[Corpus], site_map: SiteMap,
-                 driver: Path,
-                 morph_url: str = "") -> None:
+    def __init__(
+        self,
+        corpora: list[Corpus],
+        site_map: SiteMap,
+        driver: Path,
+    ) -> None:
         self._corpora = corpora
         self._site_map = site_map
         self._driver = Path(driver)
-        self._morph_url = morph_url
         self._selector = StrategySelector()
 
     def run(self) -> None:
@@ -76,19 +80,30 @@ class BuildPipeline:
                         self._site_map.citations_path(doc.metadata.urn)
                     )
                 except ConfigurationError as exc:
-                    print(f"  WARNING:  {doc.path.name}: citation index skipped ({exc})")
+                    print(
+                        f"  WARNING:  {doc.path.name}: citation index skipped ({exc})"
+                    )
+
+                annotations_path = self._site_map.annotations_path(doc.metadata.urn)
+
+                try:
+                    write_annotations(
+                        ChunkIndexer(doc.path).generate_chunks(), annotations_path
+                    )
+                except Exception as exc:
+                    print(f"  WARNING: {doc.path.name}: NLP analysis skipped ({exc})")
 
                 try:
                     compiler = PageCompiler(
                         strategy=strategy,
                         driver=self._driver,
-                        morph_url=self._morph_url,
+                        annotations_file=annotations_path,
                     )
                     output_path = self._site_map.chunk_dir(doc.metadata.urn)
                     catalog_path = self._site_map.catalog_path(doc.metadata.language)
-                    catalog_url = os.path.relpath(
-                        catalog_path, output_path
-                    ).replace("\\", "/")
+                    catalog_url = os.path.relpath(catalog_path, output_path).replace(
+                        "\\", "/"
+                    )
                     compiler.compile(doc, output_path, catalog_url=catalog_url)
                     metadata.append(doc.metadata)
                     print(f"  compiled: {doc.metadata.urn}")
@@ -96,8 +111,7 @@ class BuildPipeline:
                     errors.append(exc)
                     print(f"  FAILED:   {exc}")
 
-        print(f"\nCompiled {len(metadata)} documents, "
-              f"{len(errors)} failures.")
+        print(f"\nCompiled {len(metadata)} documents, {len(errors)} failures.")
 
         if metadata:
             catalog_compiler = CatalogCompiler(site_map=self._site_map)

--- a/src/python/mvp/site_map.py
+++ b/src/python/mvp/site_map.py
@@ -44,6 +44,9 @@ class SiteMap:
     def root(self) -> Path:
         return self._root
 
+    def annotations_path(self, urn: str) -> Path:
+        return self.chunk_dir(urn) / "annotations.json"
+
     def chunk_dir(self, urn: str) -> Path:
         """Return the output directory for chunk pages of a document.
 

--- a/src/tools/run_build.py
+++ b/src/tools/run_build.py
@@ -110,16 +110,6 @@ def main() -> None:
         help=f"Directory containing XSLT stylesheets (default: {_DEFAULT_XSLT_ROOT})",
     )
     parser.add_argument(
-        "--morph-url",
-        default="",
-        metavar="URL",
-        help=(
-            "Base URL of the morphological server (e.g. http://localhost:5000). "
-            "When set, every word in the output is linked to /morph?form=...&lang=... "
-            "on that server.  Omit for a plain static build."
-        ),
-    )
-    parser.add_argument(
         "paths",
         nargs="+",
         type=Path,
@@ -150,11 +140,11 @@ def main() -> None:
     print(f"XSLT:    {args.xslt_root}")
     print()
 
+    driver = args.xslt_root / "html" / "driver.xsl"
     pipeline = BuildPipeline(
         corpora=[Corpus(cp) for cp in corpus_paths],
         site_map=SiteMap(output_root),
-        xslt_root=args.xslt_root,
-        morph_url=args.morph_url,
+        driver=driver,
     )
     pipeline.run()
 

--- a/src/xslt/html/driver.xsl
+++ b/src/xslt/html/driver.xsl
@@ -12,11 +12,12 @@
   $citation-table, or any other rendering enrichment.
 
   Enrichment parameters declared here:
-    $morph-url       — when non-empty, word tokens are linked to a morphological
-                       server.  Consumed by the text() template in perseus_base.xsl.
-    $citation-table  — path/URL of a compiled citation link table.  Loaded via
-                       document() and injected as $citation-map.  Not yet designed;
-                       present to stabilise the driver interface.
+    $annotations-file — file URI of the pre-computed NLP annotations JSON sidecar.
+                        Loaded via json-doc() and passed as $annotations-map tunnel
+                        param.  Consumed by the text() template in perseus_base.xsl.
+    $citation-table   — path/URL of a compiled citation link table.  Loaded via
+                        document() and injected as $citation-map.  Not yet designed;
+                        present to stabilise the driver interface.
 
   Dispatch parameters:
     $chunk-strategy  — 'milestone' | 'div' | 'auto' (default).
@@ -53,8 +54,8 @@
        ============================================================ -->
 
   <!-- Enrichment parameters — owned exclusively by the driver -->
-  <xsl:param name="morph-url"      as="xs:string" select="''"/>
-  <xsl:param name="citation-table" as="xs:string" select="''"/>
+  <xsl:param name="annotations-file" as="xs:string" select="''"/>
+  <xsl:param name="citation-table"   as="xs:string" select="''"/>
 
   <!-- Structural parameters — redeclared here for documentation;
        the chunkers also declare these and will receive command-line values. -->
@@ -126,7 +127,9 @@
     <xsl:param name="next-file"   as="xs:string?"/>
     <xsl:param name="all-chunks"  as="map(*)*"/>
 
-    <!-- Load citation map if a table path was provided -->
+    <!-- Load annotations map and citation map if paths were provided -->
+    <xsl:variable name="annotations-map"
+      select="if ($annotations-file != '') then json-doc($annotations-file) else map{}"/>
     <xsl:variable name="citation-map"
       select="if ($citation-table != '') then document($citation-table) else ()"/>
 
@@ -177,8 +180,8 @@
                 <xsl:apply-templates select="$chunk" mode="chunk">
                   <xsl:with-param name="start"        tunnel="yes" select="$start"/>
                   <xsl:with-param name="stop"         tunnel="yes" select="$stop"/>
-                  <xsl:with-param name="morph-url"    tunnel="yes" select="$morph-url"/>
-                  <xsl:with-param name="citation-map" tunnel="yes" select="$citation-map"/>
+                  <xsl:with-param name="annotations-map" tunnel="yes" select="$annotations-map"/>
+                  <xsl:with-param name="citation-map"   tunnel="yes" select="$citation-map"/>
                 </xsl:apply-templates>
               </div>
               <xsl:call-template name="page:passage-footer"/>

--- a/src/xslt/html/tei/perseus_base.xsl
+++ b/src/xslt/html/tei/perseus_base.xsl
@@ -60,25 +60,6 @@
     <xsl:value-of select="'/' || string-join($parts, '/')"/>
   </xsl:function>
 
-  <!--
-    local:strip-punct($s) → xs:string
-    Remove leading and trailing punctuation from a token so the bare
-    surface form can be submitted to the morphological server.
-    Mirrors the same function in tokenize.xsl.
-  -->
-  <xsl:function name="local:strip-punct" as="xs:string">
-    <xsl:param name="s" as="xs:string"/>
-    <xsl:variable name="s1"
-      select="replace($s,
-                '^[.,;:!?·—–(){}\[\]&lt;&gt;⟨⟩&quot;]+', '')"/>
-    <xsl:variable name="s2"
-      select="replace($s1,
-                '[.,;:!?·—–(){}\[\]&lt;&gt;⟨⟩&quot;]+$', '')"/>
-    <xsl:variable name="s3" select="replace($s2, &quot;^'+&quot;, '')"/>
-    <xsl:variable name="s4" select="replace($s3, &quot;'+$&quot;,  '')"/>
-    <xsl:sequence select="$s4"/>
-  </xsl:function>
-
   <!-- ============================================================
        Structural elements
        ============================================================ -->
@@ -267,12 +248,14 @@
 
   <!--
     Text nodes (leaf).
-    When $annotations-map is non-empty, each whitespace-delimited token is
-    wrapped in a <span class="word"> carrying NLP data attributes (lemma, pos,
-    etc.) looked up from the pre-computed annotations sidecar.  The nearest
-    chunk ancestor's XPath is used as the sidecar key; within that chunk,
-    tokens are matched by surface form (punctuation stripped).
-    Whitespace-only nodes pass through unchanged in both modes.
+    When $annotations-map is non-empty, each token is wrapped in a
+    <span class="word"> carrying NLP data attributes (lemma, upos, etc.)
+    drawn directly from the pre-computed annotations sidecar.  The nearest
+    chunk ancestor's XPath is the sidecar key; the token slice for this
+    text node is located by counting whitespace-delimited tokens in all
+    preceding text nodes within the chunk.  Display text and inter-token
+    whitespace both come from the sidecar token, not from re-tokenizing
+    the source text.  Whitespace-only nodes pass through unchanged.
   -->
   <xsl:template match="text()" mode="tei-to-html">
     <xsl:param name="annotations-map" tunnel="yes" as="map(*)" select="map{}"/>
@@ -282,47 +265,36 @@
           select="(ancestor::*[local-name() = ('p','l','lg','ab')])[1]"/>
         <xsl:variable name="chunk-tokens" as="array(*)?">
           <xsl:if test="exists($chunk-elem)">
-            <xsl:variable name="chunk-xpath" select="local:xpath-for($chunk-elem)"/>
-            <xsl:sequence select="$annotations-map($chunk-xpath)?tokens"/>
+            <xsl:sequence select="$annotations-map(local:xpath-for($chunk-elem))?tokens"/>
           </xsl:if>
         </xsl:variable>
-        <xsl:variable name="normalized" select="normalize-space(.)"/>
-        <xsl:if test="$normalized != ''">
-          <xsl:if test="matches(., '^\s')">
-            <xsl:text> </xsl:text>
-          </xsl:if>
-          <xsl:for-each select="tokenize($normalized, '\s+')">
-            <xsl:variable name="raw"     select="."/>
-            <xsl:variable name="surface" select="local:strip-punct($raw)"/>
-            <xsl:variable name="token-data" as="map(*)?">
-              <xsl:if test="exists($chunk-tokens) and $surface != ''">
-                <xsl:sequence select="($chunk-tokens?*[?text = $surface])[1]"/>
+        <xsl:choose>
+          <xsl:when test="normalize-space(.) != '' and exists($chunk-tokens)">
+            <xsl:variable name="offset" as="xs:integer"
+              select="sum(
+                for $t in ($chunk-elem//text()[. &lt;&lt; current()])
+                return count(tokenize(normalize-space($t), '\s+')[. != ''])
+              )"/>
+            <xsl:variable name="n" as="xs:integer"
+              select="count(tokenize(normalize-space(.), '\s+')[. != ''])"/>
+            <xsl:for-each select="1 to $n">
+              <xsl:variable name="tok" select="$chunk-tokens($offset + .)"/>
+              <span class="word">
+                <xsl:if test="map:contains($tok, 'lemma')">
+                  <xsl:attribute name="data-lemma" select="$tok?lemma"/>
+                </xsl:if>
+                <xsl:if test="map:contains($tok, 'upos')">
+                  <xsl:attribute name="data-upos" select="$tok?upos"/>
+                </xsl:if>
+                <xsl:value-of select="$tok?text"/>
+              </span>
+              <xsl:if test="$tok?whitespace">
+                <xsl:text> </xsl:text>
               </xsl:if>
-            </xsl:variable>
-            <xsl:choose>
-              <xsl:when test="exists($token-data)">
-                <span class="word">
-                  <xsl:if test="map:contains($token-data, 'lemma')">
-                    <xsl:attribute name="data-lemma" select="$token-data?lemma"/>
-                  </xsl:if>
-                  <xsl:if test="map:contains($token-data, 'pos')">
-                    <xsl:attribute name="data-pos" select="$token-data?pos"/>
-                  </xsl:if>
-                  <xsl:value-of select="$raw"/>
-                </span>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="$raw"/>
-              </xsl:otherwise>
-            </xsl:choose>
-            <xsl:if test="position() != last()">
-              <xsl:text> </xsl:text>
-            </xsl:if>
-          </xsl:for-each>
-          <xsl:if test="matches(., '\s$')">
-            <xsl:text> </xsl:text>
-          </xsl:if>
-        </xsl:if>
+            </xsl:for-each>
+          </xsl:when>
+          <xsl:otherwise><xsl:copy/></xsl:otherwise>
+        </xsl:choose>
       </xsl:when>
       <xsl:otherwise>
         <xsl:copy/>

--- a/src/xslt/html/tei/perseus_base.xsl
+++ b/src/xslt/html/tei/perseus_base.xsl
@@ -17,7 +17,7 @@
     rather than mode="tei-to-html". This keeps chunk-boundary filtering active
     for every child node, which is required to handle the straddling case: a
     container element that spans a chunk boundary must still suppress content
-    on the far side. Tunnel params ($start, $stop, $morph-url) flow through
+    on the far side. Tunnel params ($start, $stop, $annotations-map) flow through
     implicitly and are never declared by mode="tei-to-html" templates.
 
   Leaf templates (tei:gap, tei:lb, tei:pb|tei:milestone, text()) produce
@@ -30,15 +30,35 @@
   xmlns:xsl  ="http://www.w3.org/1999/XSL/Transform"
   xmlns:tei  ="http://www.tei-c.org/ns/1.0"
   xmlns:xs   ="http://www.w3.org/2001/XMLSchema"
+  xmlns:map  ="http://www.w3.org/2005/xpath-functions/map"
   xmlns:local="http://local.functions"
   version="3.0"
-  exclude-result-prefixes="tei xs local">
+  exclude-result-prefixes="tei xs map local">
 
   <xsl:import href="../variables.xsl"/>
 
   <!-- ============================================================
        Helper functions
        ============================================================ -->
+
+  <!--
+    local:xpath-for($node) → xs:string
+    Returns the XPath of $node using tei:-prefixed steps with positional
+    predicates, e.g. /tei:TEI[1]/tei:text[1]/tei:body[1]/tei:p[1].
+    Mirrors ChunkIndexer.xpath_for() in indexers.py so the keys produced
+    here match the keys in the annotations JSON sidecar.
+  -->
+  <xsl:function name="local:xpath-for" as="xs:string">
+    <xsl:param name="node" as="element()"/>
+    <xsl:variable name="parts" as="xs:string*">
+      <xsl:for-each select="$node/ancestor-or-self::*">
+        <xsl:variable name="name"  select="local-name(.)"/>
+        <xsl:variable name="index" select="count(preceding-sibling::*[local-name() = $name]) + 1"/>
+        <xsl:sequence select="concat('tei:', $name, '[', $index, ']')"/>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:value-of select="'/' || string-join($parts, '/')"/>
+  </xsl:function>
 
   <!--
     local:strip-punct($s) → xs:string
@@ -247,27 +267,25 @@
 
   <!--
     Text nodes (leaf).
-    When $morph-url is set, each whitespace-delimited token is wrapped in
-    an <a class="word"> linking to the morphological server.  The bare
-    surface form (punctuation stripped) is used as the lookup key; the
-    original raw token (with punctuation) is the visible link text.
+    When $annotations-map is non-empty, each whitespace-delimited token is
+    wrapped in a <span class="word"> carrying NLP data attributes (lemma, pos,
+    etc.) looked up from the pre-computed annotations sidecar.  The nearest
+    chunk ancestor's XPath is used as the sidecar key; within that chunk,
+    tokens are matched by surface form (punctuation stripped).
     Whitespace-only nodes pass through unchanged in both modes.
   -->
-  <!-- $morph-url is injected by the driver at the apply-templates call site in
-       page:render, so it enters mode="chunk" from outside the chunking infrastructure.
-       This resolves the mode-boundary violation noted in the #implement-tei-to-html-process
-       review; the TODO about interim mechanism status still applies. -->
   <xsl:template match="text()" mode="tei-to-html">
-    <xsl:param name="morph-url" tunnel="yes" as="xs:string" select="''"/>
+    <xsl:param name="annotations-map" tunnel="yes" as="map(*)" select="map{}"/>
     <xsl:choose>
-      <xsl:when test="$morph-url != ''">
-        <xsl:variable name="tei-lang"
-          select="(ancestor::*[@xml:lang])[1]/@xml:lang"/>
-        <xsl:variable name="morph-lang" select="
-          if      ($tei-lang = 'lat') then 'la'
-          else if ($tei-lang = 'grc') then 'grc'
-          else ''
-        "/>
+      <xsl:when test="map:size($annotations-map) gt 0">
+        <xsl:variable name="chunk-elem"
+          select="(ancestor::*[local-name() = ('p','l','lg','ab')])[1]"/>
+        <xsl:variable name="chunk-tokens" as="array(*)?">
+          <xsl:if test="exists($chunk-elem)">
+            <xsl:variable name="chunk-xpath" select="local:xpath-for($chunk-elem)"/>
+            <xsl:sequence select="$annotations-map($chunk-xpath)?tokens"/>
+          </xsl:if>
+        </xsl:variable>
         <xsl:variable name="normalized" select="normalize-space(.)"/>
         <xsl:if test="$normalized != ''">
           <xsl:if test="matches(., '^\s')">
@@ -276,10 +294,22 @@
           <xsl:for-each select="tokenize($normalized, '\s+')">
             <xsl:variable name="raw"     select="."/>
             <xsl:variable name="surface" select="local:strip-punct($raw)"/>
+            <xsl:variable name="token-data" as="map(*)?">
+              <xsl:if test="exists($chunk-tokens) and $surface != ''">
+                <xsl:sequence select="($chunk-tokens?*[?text = $surface])[1]"/>
+              </xsl:if>
+            </xsl:variable>
             <xsl:choose>
-              <xsl:when test="$morph-lang != '' and $surface != ''">
-                <a href="{$morph-url}/morph?form={encode-for-uri($surface)}&amp;lang={$morph-lang}"
-                   class="word"><xsl:value-of select="$raw"/></a>
+              <xsl:when test="exists($token-data)">
+                <span class="word">
+                  <xsl:if test="map:contains($token-data, 'lemma')">
+                    <xsl:attribute name="data-lemma" select="$token-data?lemma"/>
+                  </xsl:if>
+                  <xsl:if test="map:contains($token-data, 'pos')">
+                    <xsl:attribute name="data-pos" select="$token-data?pos"/>
+                  </xsl:if>
+                  <xsl:value-of select="$raw"/>
+                </span>
               </xsl:when>
               <xsl:otherwise>
                 <xsl:value-of select="$raw"/>


### PR DESCRIPTION
This PR adds support for calling the NLP pipeline server over HTTP. It replaces the deferred calls to Morpheus with build-time analysis of "chunks" produced by the `ChunkIndexer`, inlining the results as `data-` attributes on `span` elements in the HTML output.

Note that we might still want to implement calls to some kind of lookup/lexicon server. We could use Morpheus for that purpose, or we could point to an external server, integrating more deeply with the broader community.

I'm opening the PR now for feedback and suggestions, but I would like to implement some sort of lexicon link before merging.