### PR TITLE
Update perseus-cts pin: delim guard now on main

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -772,7 +772,7 @@ name = "perseus-cts"
 version = "0.1.0"
 requires_python = ">=3.12"
 git = "https://github.com/PerseusDLCode/perseus-cts.git"
-revision = "5a91448d8ccdf88f22c2c9349c07138eb2939d35"
+revision = "4bd6f1263d9ab0042b89a338878b77488125d861"
 summary = "CTS resolver, chunker, and TEI document models for the Perseus Digital Library"
 groups = ["default"]
 dependencies = [


### PR DESCRIPTION
## Summary

Updates the `perseus-cts` git pin in `pdm.lock` from `5a91448` to `4bd6f12` (current `main`).

The new pin includes:
- A `ConfigurationError` guard in `CTSResolver.__init__` that rejects documents whose first-level `citeStructure` declares `delim` other than `':'`, preventing silent generation of broken dot-joined URNs.
- `scripts/fix_first_level_delim.py`, the backfill tool used to fix 1,766 affected corpus files.

The corpus data fix and the normalizer fix (`corpus-tools`) have already been applied and pushed separately.

## Test plan

- [ ] `pdm install` picks up the new revision cleanly
- [ ] Proto-page generation still produces ~2,562 documents with 0 dot-joined URNs

Generated with Claude Code