### PR TITLE
Update perseus-cts pin: add compile_corpus.py standalone CLI

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -772,7 +772,7 @@ name = "perseus-cts"
 version = "0.1.0"
 requires_python = ">=3.12"
 git = "https://github.com/PerseusDLCode/perseus-cts.git"
-revision = "5a91448d8ccdf88f22c2c9349c07138eb2939d35"
+revision = "4bd6f1263d9ab0042b89a338878b77488125d861"
 summary = "CTS resolver, chunker, and TEI document models for the Perseus Digital Library"
 groups = ["default"]
 dependencies = [

--- a/pdm.lock
+++ b/pdm.lock
@@ -772,7 +772,7 @@ name = "perseus-cts"
 version = "0.1.0"
 requires_python = ">=3.12"
 git = "https://github.com/PerseusDLCode/perseus-cts.git"
-revision = "4bd6f1263d9ab0042b89a338878b77488125d861"
+revision = "3bda8daa217518e1ed47442053a31a22e1b8be7a"
 summary = "CTS resolver, chunker, and TEI document models for the Perseus Digital Library"
 groups = ["default"]
 dependencies = [


### PR DESCRIPTION
## Summary

Updates `perseus-cts` pin from `4bd6f12` to `3bda8da`.

Adds `scripts/compile_corpus.py` to `perseus-cts`: a standalone CLI that runs `Chunker.compile()` independently of MVP. Corpus proto-pages can now be regenerated without Flask as a dependency.

Usage:
```sh
# dry run
pdm run python scripts/compile_corpus.py --output ../proto-pages

# compile
pdm run python scripts/compile_corpus.py --output ../proto-pages --write
```

Generated with Claude Code