### PR TITLE
Fix default CORPORA_DIR to use corpora/ instead of ../canonicalLit

### DIFF
--- a/src/python/mvp/site/app.py
+++ b/src/python/mvp/site/app.py
@@ -20,7 +20,7 @@ from mvp.site.tei_parser import TEIParser, TEIParserError, inject_tokens
 
 APP_DIR = Path(__file__).resolve().parent
 ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent.parent
-CORPORA_DIR = Path(os.getenv("CORPORA_DIR", ROOT_DIR / ".." / "canonicalLit"))
+CORPORA_DIR = Path(os.getenv("CORPORA_DIR", ROOT_DIR / "corpora"))
 MARKDOWN_DIR = APP_DIR / "static" / "markdown"
 NEWS_MARKDOWN = MARKDOWN_DIR / "news.md"
 RESEARCH_MARKDOWN = MARKDOWN_DIR / "research.md"


### PR DESCRIPTION
## Summary

- Changes the `CORPORA_DIR` default in `app.py` from `ROOT_DIR / ".." / "canonicalLit"` to `ROOT_DIR / "corpora"`
- The old path pointed to a `canonicalLit` directory (presumably a clone of Peter's canonicalLit repository, which, I believe, has now been deprecated) ; `corpora/` is the directory the README already documents for per-corpus symlinks (e.g. `corpora/latinLit → data-local/canonical-latinLit`)
